### PR TITLE
fix: never block the device's default launcher

### DIFF
--- a/app/src/main/java/neth/iecal/curbox/blockers/AppBlocker.kt
+++ b/app/src/main/java/neth/iecal/curbox/blockers/AppBlocker.kt
@@ -30,6 +30,7 @@ import neth.iecal.curbox.utils.ShizukuRunner
 import neth.iecal.curbox.utils.TimeTools
 import neth.iecal.curbox.utils.TimerNotification
 import neth.iecal.curbox.utils.UsageStatsHelper
+import neth.iecal.curbox.utils.getDefaultLauncherPackageName
 import java.util.Calendar
 import java.util.concurrent.ConcurrentHashMap
 
@@ -67,6 +68,7 @@ class AppBlocker() : BaseBlocker() {
 
     private lateinit var usageStats : UsageStatsHelper
     private var lastPackage = ""
+    private var launcherPackage: String? = null
     private lateinit var service: BaseBlockingService
 
 
@@ -85,6 +87,9 @@ class AppBlocker() : BaseBlocker() {
         val packageName = event.packageName?.toString() ?: return
 
         if (lastPackage == packageName || packageName == service.packageName || packageName == "com.android.systemui") return
+
+        // Never block the device's launcher — blocking it would press-home into itself.
+        if (packageName == launcherPackage) return
 
         lastPackage = packageName
 
@@ -157,6 +162,7 @@ class AppBlocker() : BaseBlocker() {
         prefs = service.getSharedPreferences("app_blocker_prefs", Context.MODE_PRIVATE)
         loadPersistedData()
         usageStats = UsageStatsHelper(service)
+        launcherPackage = getDefaultLauncherPackageName(service.packageManager)
         CoroutineScope(Dispatchers.IO).launch {
             service.dataStoreManager.settings.collectLatest { settings ->
                 // Clear existing thread-safe maps and repopulate them

--- a/app/src/main/java/neth/iecal/curbox/blockers/AppBlocker.kt
+++ b/app/src/main/java/neth/iecal/curbox/blockers/AppBlocker.kt
@@ -30,7 +30,7 @@ import neth.iecal.curbox.utils.ShizukuRunner
 import neth.iecal.curbox.utils.TimeTools
 import neth.iecal.curbox.utils.TimerNotification
 import neth.iecal.curbox.utils.UsageStatsHelper
-import neth.iecal.curbox.utils.getDefaultLauncherPackageName
+import neth.iecal.curbox.utils.getEssentialPackages
 import java.util.Calendar
 import java.util.concurrent.ConcurrentHashMap
 
@@ -68,7 +68,7 @@ class AppBlocker() : BaseBlocker() {
 
     private lateinit var usageStats : UsageStatsHelper
     private var lastPackage = ""
-    private var launcherPackage: String? = null
+    private var essentialPackages: Set<String> = emptySet()
     private lateinit var service: BaseBlockingService
 
 
@@ -86,10 +86,7 @@ class AppBlocker() : BaseBlocker() {
 
         val packageName = event.packageName?.toString() ?: return
 
-        if (lastPackage == packageName || packageName == service.packageName || packageName == "com.android.systemui") return
-
-        // Never block the device's launcher — blocking it would press-home into itself.
-        if (packageName == launcherPackage) return
+        if (lastPackage == packageName || essentialPackages.contains(packageName)) return
 
         lastPackage = packageName
 
@@ -162,7 +159,7 @@ class AppBlocker() : BaseBlocker() {
         prefs = service.getSharedPreferences("app_blocker_prefs", Context.MODE_PRIVATE)
         loadPersistedData()
         usageStats = UsageStatsHelper(service)
-        launcherPackage = getDefaultLauncherPackageName(service.packageManager)
+        essentialPackages = getEssentialPackages(service)
         CoroutineScope(Dispatchers.IO).launch {
             service.dataStoreManager.settings.collectLatest { settings ->
                 // Clear existing thread-safe maps and repopulate them

--- a/app/src/main/java/neth/iecal/curbox/blockers/FocusModeBlocker.kt
+++ b/app/src/main/java/neth/iecal/curbox/blockers/FocusModeBlocker.kt
@@ -157,10 +157,12 @@ class FocusModeBlocker : BaseBlocker() {
         if (focusModeData != null) {
             when (focusModeData!!.focusGroupData.blockMode) {
                 FocusBlockMode.BLOCK_SELECTED -> {
-                    if (focusModeData!!.focusGroupData.packages.contains(packageName)) performBlock()
+                    if (focusModeData!!.focusGroupData.packages.contains(packageName)
+                        && !essentialPackages.contains(packageName)) performBlock()
                 }
                 FocusBlockMode.BLOCK_ALL_EXCEPT_SELECTED -> {
-                    if (!focusModeData!!.focusGroupData.packages.contains(packageName)) performBlock()
+                    if (!focusModeData!!.focusGroupData.packages.contains(packageName)
+                        && !essentialPackages.contains(packageName)) performBlock()
                 }
             }
             if (focusModeData!!.endTimeInMillis < System.currentTimeMillis()) {
@@ -191,7 +193,8 @@ class FocusModeBlocker : BaseBlocker() {
             anyAutoFocusActive = true
             activeAutoFocusGroupId = group.groupId
             val blocked = when (group.blockMode) {
-                FocusBlockMode.BLOCK_SELECTED -> group.packages.contains(packageName)
+                FocusBlockMode.BLOCK_SELECTED ->
+                    group.packages.contains(packageName) && !essentialPackages.contains(packageName)
                 FocusBlockMode.BLOCK_ALL_EXCEPT_SELECTED ->
                     !group.packages.contains(packageName) && !essentialPackages.contains(packageName)
             }

--- a/app/src/main/java/neth/iecal/curbox/blockers/FocusModeBlocker.kt
+++ b/app/src/main/java/neth/iecal/curbox/blockers/FocusModeBlocker.kt
@@ -29,8 +29,7 @@ import neth.iecal.curbox.data.models.TimeInterval
 import neth.iecal.curbox.services.BaseBlockingService
 import neth.iecal.curbox.utils.AppSuspendHelper
 import neth.iecal.curbox.utils.TimerNotification
-import neth.iecal.curbox.utils.getCurrentKeyboardPackageName
-import neth.iecal.curbox.utils.getDefaultLauncherPackageName
+import neth.iecal.curbox.utils.getEssentialPackages
 import java.util.Calendar
 
 class FocusModeBlocker : BaseBlocker() {
@@ -145,7 +144,7 @@ class FocusModeBlocker : BaseBlocker() {
 
     fun doFocusModeCheck(event: AccessibilityEvent?) {
         val packageName = event?.packageName.toString()
-        if (lastPackage == packageName || packageName == service.getPackageName()) return
+        if (lastPackage == packageName) return
         lastPackage = packageName
 
         fun performBlock() {
@@ -327,12 +326,7 @@ class FocusModeBlocker : BaseBlocker() {
         notificationManager = TimerNotification(service)
         createAutoFocusNotificationChannel()
 
-        // cache essential packages
-        val essential = mutableSetOf("com.android.systemui")
-        getDefaultLauncherPackageName(service.packageManager)?.let { essential.add(it) }
-        getCurrentKeyboardPackageName(service)?.let { essential.add(it) }
-        essentialPackages = essential
-
+        essentialPackages = getEssentialPackages(service)
         Log.d("essential package", essentialPackages.toString())
         CoroutineScope(Dispatchers.IO).launch {
             val db = neth.iecal.curbox.data.db.AppDatabase.getInstance(service)
@@ -351,9 +345,6 @@ class FocusModeBlocker : BaseBlocker() {
                 if (settings.activeManualFocusGroupId.first != null) {
                     val currentFocusingGroup = settings.manualFocusGroups.find { it.groupId == settings.activeManualFocusGroupId.first }
                     if (currentFocusingGroup != null && settings.activeManualFocusGroupId.second > System.currentTimeMillis()) {
-                        if (currentFocusingGroup.blockMode == FocusBlockMode.BLOCK_ALL_EXCEPT_SELECTED) {
-                            currentFocusingGroup.packages.addAll(essentialPackages)
-                        }
                         focusModeData = ManualFocusModeData(currentFocusingGroup, settings.activeManualFocusGroupId.second)
                         withContext(Dispatchers.Main) {
                             notificationManager.startTimer(

--- a/app/src/main/java/neth/iecal/curbox/ui/activity/SelectAppsActivity.kt
+++ b/app/src/main/java/neth/iecal/curbox/ui/activity/SelectAppsActivity.kt
@@ -28,6 +28,7 @@ import neth.iecal.curbox.R
 import neth.iecal.curbox.databinding.ActivitySelectAppsBinding
 import neth.iecal.curbox.databinding.DialogAddKeywordBinding
 import neth.iecal.curbox.utils.DataStoreManager
+import neth.iecal.curbox.utils.getEssentialPackages
 
 class SelectAppsActivity : AppCompatActivity() {
 
@@ -72,7 +73,9 @@ class SelectAppsActivity : AppCompatActivity() {
             intent.getStringArrayListExtra("PRE_SELECTED_APPS")?.toHashSet() ?: HashSet()
 
         ignoredApps = intent.getStringArrayListExtra("IGNORED_APPS")?.toHashSet() ?: HashSet()
-        ignoredApps.add(packageName) // also remove curbox app from the list
+        // Hide essentials (launcher, keyboard, system UI, our own app) from the picker —
+        // blockers refuse to act on them, so showing them would be misleading.
+        ignoredApps.addAll(getEssentialPackages(this))
 
         Log.d("pre-selected-apps", selectedAppList.toString())
 
@@ -170,7 +173,7 @@ class SelectAppsActivity : AppCompatActivity() {
         }
         if (intent.hasExtra("APP_LIST")) {
             val appList = intent.getStringArrayListExtra("APP_LIST")
-            appList?.forEach { packageName ->
+            appList?.filterNot { ignoredApps.contains(it) }?.forEach { packageName ->
                 try {
                     val appInfo = packageManager.getApplicationInfo(packageName, 0)
                     appItemList.add(
@@ -205,7 +208,7 @@ class SelectAppsActivity : AppCompatActivity() {
 
             // Add uninstalled apps from selectedAppList that aren't already included
             selectedAppList.forEach { packageName ->
-                if (!installedPackages.contains(packageName)) {
+                if (!installedPackages.contains(packageName) && !ignoredApps.contains(packageName)) {
                     try {
                         val appInfo = packageManager.getApplicationInfo(packageName, 0)
                         appItemList.add(

--- a/app/src/main/java/neth/iecal/curbox/utils/AppSuspendHelper.kt
+++ b/app/src/main/java/neth/iecal/curbox/utils/AppSuspendHelper.kt
@@ -33,7 +33,7 @@ object AppSuspendHelper {
         essentialPackages: Set<String>
     ): List<String> {
         return if (blockMode == FocusBlockMode.BLOCK_SELECTED) {
-            groupPackages.toList()
+            groupPackages.filter { it !in essentialPackages }
         } else {
             val allPackages = context.packageManager.getInstalledPackages(0).map { it.packageName }
             allPackages.filter { it !in groupPackages && it !in essentialPackages }

--- a/app/src/main/java/neth/iecal/curbox/utils/EssentialPackages.kt
+++ b/app/src/main/java/neth/iecal/curbox/utils/EssentialPackages.kt
@@ -1,0 +1,23 @@
+package neth.iecal.curbox.utils
+
+import android.content.Context
+
+/**
+ * Packages that must never be blocked, suspended, or force-stopped.
+ *
+ * Blocking these would either brick basic device interaction (launcher, keyboard,
+ * system UI) or recursively re-trigger the blocker (the app itself, since blocking
+ * presses HOME — which goes to the launcher — and force-stops the offending app).
+ *
+ * Single source of truth — every blocker, suspender, and picker reads from here.
+ * Add new categories (dialer, accessibility services, etc.) in one place.
+ */
+fun getEssentialPackages(context: Context): Set<String> {
+    val essential = mutableSetOf(
+        "com.android.systemui",
+        context.packageName,
+    )
+    getDefaultLauncherPackageName(context.packageManager)?.let(essential::add)
+    getCurrentKeyboardPackageName(context)?.let(essential::add)
+    return essential
+}


### PR DESCRIPTION
AppBlocker had no launcher exclusion: a launcher added to a Usage or Time block group would be force-stopped and the user sent to home, which is itself the launcher — an infinite block loop. Cache the launcher package in setupAppBlocker (refreshed via the existing refresh broadcast) and short-circuit doAppBlockerCheck before consulting either blocklist.

FocusModeBlocker's BLOCK_SELECTED branches did not consult essentialPackages, so a selected launcher would be blocked in both manual and auto focus. Added the essentialPackages guard to both BLOCK_SELECTED branches, plus the manual BLOCK_ALL_EXCEPT_SELECTED branch for symmetry (previously only covered indirectly via setupFocusMode mutating the group's packages set).

AppSuspendHelper.getPackagesToSuspend returned groupPackages.toList() unfiltered for BLOCK_SELECTED, so a selected launcher would be pm-suspended via Shizuku. Filter essentialPackages out of that branch too.