### PR TITLE
Add support for Iceraven browser

### DIFF
--- a/app/src/main/java/neth/iecal/curbox/hardcoded/BrowserUrlBarIds.kt
+++ b/app/src/main/java/neth/iecal/curbox/hardcoded/BrowserUrlBarIds.kt
@@ -30,7 +30,10 @@ val URL_BAR_ID_LIST = mapOf(
     "org.ironfoxoss.ironfox" to BrowserUrlBarInfo(
         displayUrlBarId = "ADDRESSBAR_URL_BOX",
     ),
-
+    "io.github.forkmaintainers.iceraven" to BrowserUrlBarInfo(
+        displayUrlBarId = "ADDRESSBAR_URL_BOX",
+    ),
+    
 
     "com.opera.browser" to BrowserUrlBarInfo(
         displayUrlBarId = "com.opera.browser:id/url_field",


### PR DESCRIPTION
Add support for https://github.com/fork-maintainers/iceraven-browser
(Firefox-based) 