### PR TITLE
Add support for firefox focus browser

### DIFF
--- a/app/src/main/java/neth/iecal/curbox/hardcoded/BrowserUrlBarIds.kt
+++ b/app/src/main/java/neth/iecal/curbox/hardcoded/BrowserUrlBarIds.kt
@@ -24,6 +24,9 @@ val URL_BAR_ID_LIST = mapOf(
     "org.mozilla.firefox" to BrowserUrlBarInfo(
         displayUrlBarId = "ADDRESSBAR_URL_BOX",
     ),
+    "org.mozilla.focus" to BrowserUrlBarInfo(
+        displayUrlBarId = "ADDRESSBAR_URL_BOX",
+    ),
     "org.mozilla.fennec_fdroid" to BrowserUrlBarInfo(
         displayUrlBarId = "ADDRESSBAR_URL_BOX",
     ),

--- a/app/src/main/java/neth/iecal/curbox/hardcoded/BrowserUrlBarIds.kt
+++ b/app/src/main/java/neth/iecal/curbox/hardcoded/BrowserUrlBarIds.kt
@@ -20,13 +20,15 @@ val URL_BAR_ID_LIST = mapOf(
         displayUrlBarId = "com.vivaldi.browser:id/url_bar",
     ),
 
+    
+    "org.mozilla.focus" to BrowserUrlBarInfo(
+        displayUrlBarId = "org.mozilla.focus:id/mozac_browser_toolbar_url_view",
+    ),
 
     "org.mozilla.firefox" to BrowserUrlBarInfo(
         displayUrlBarId = "ADDRESSBAR_URL_BOX",
     ),
-    "org.mozilla.focus" to BrowserUrlBarInfo(
-        displayUrlBarId = "ADDRESSBAR_URL_BOX",
-    ),
+
     "org.mozilla.fennec_fdroid" to BrowserUrlBarInfo(
         displayUrlBarId = "ADDRESSBAR_URL_BOX",
     ),


### PR DESCRIPTION
Add support for the [Firefox Focus browser](https://play.google.com/store/apps/details?id=org.mozilla.focus).

Untested, waiting for CI build and will update when tested.