### PR TITLE
keyword blocker: double back-press with 250ms delays to prevent browser lockout

### DIFF
--- a/app/src/main/java/neth/iecal/curbox/blockers/KeywordBlocker.kt
+++ b/app/src/main/java/neth/iecal/curbox/blockers/KeywordBlocker.kt
@@ -185,8 +185,9 @@ class KeywordBlocker : BaseBlocker() {
     }
 
     private fun handleBlocking(group: KeywordGroup) {
-        Thread.sleep(250) //we need three waits for the Chrome ui to update the blocked word in the address bar
+        //we need three waits for the Chrome ui to update the blocked word in the address bar
         // so that the user is not locked out of the browser
+        Thread.sleep(250)//if the user touches a home screen shortcut it allows time for the browser UI to update
         service.pressBack()//if the user presses a Chrome home screen shortcut, this will cause Chrome to exit
         //to the home screen, if the user is typing a blocked word it will close the keyboard
         Thread.sleep(250)

--- a/app/src/main/java/neth/iecal/curbox/blockers/KeywordBlocker.kt
+++ b/app/src/main/java/neth/iecal/curbox/blockers/KeywordBlocker.kt
@@ -185,8 +185,14 @@ class KeywordBlocker : BaseBlocker() {
     }
 
     private fun handleBlocking(group: KeywordGroup) {
-        service.pressBack()
-        Thread.sleep(1000)
+        Thread.sleep(250) //we need three waits for the Chrome ui to update the blocked word in the address bar
+        // so that the user is not locked out of the browser
+        service.pressBack()//if the user presses a Chrome home screen shortcut, this will cause Chrome to exit
+        //to the home screen, if the user is typing a blocked word it will close the keyboard
+        Thread.sleep(250)
+        service.pressBack()//we need a second back press on chrome so that the user is able to type
+        //another URL
+        Thread.sleep(250)
         service.pressHome()
         Handler(Looper.getMainLooper()).postDelayed({
             val intent = Intent(service, WarningActivity::class.java).apply {


### PR DESCRIPTION
In my experience, when using chrome and blocking URLs in the keyword blocker, the user can seem to be locked out of the browser because the keyword blocker is faster than the browser can remove the blocked  url after pressing the back button. 

Thus if the user needs to actually use the browser for  something else they need to try to enter the browser several times until the browser updates the UI and removes the blocked URL from the UI. 

This adds delays that help alleviate this issue. 
The delays are 250 ms so that they are too fast for a human but slow enough for the browser to update the UI removing the blocked URL from it. 