### PR TITLE
keyword blocker: refresh group list whenever the page is shown

### DIFF
--- a/app/src/main/java/neth/iecal/curbox/ui/fragments/main/reducers/blockertools/keywordBlocker/KeywordBlockerFragment.kt
+++ b/app/src/main/java/neth/iecal/curbox/ui/fragments/main/reducers/blockertools/keywordBlocker/KeywordBlockerFragment.kt
@@ -11,11 +11,14 @@ import android.widget.Toast
 import androidx.appcompat.widget.PopupMenu
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
+import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.google.android.material.switchmaterial.SwitchMaterial
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
@@ -44,7 +47,9 @@ class KeywordBlockerFragment : Fragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        if (!viewModel.keywordBlockerConfig.value.isActive) {
+
+        val currentConfig = viewModel.keywordBlockerConfig.value
+        if (!currentConfig.isActive) {
             viewModel.setIsActive(true)
         }
         binding.rvKeywordGroups.layoutManager = LinearLayoutManager(requireContext())
@@ -99,11 +104,12 @@ class KeywordBlockerFragment : Fragment() {
 
     private fun observeViewModel() {
         viewLifecycleOwner.lifecycleScope.launch {
-            viewModel.keywordBlockerConfig.collectLatest { config ->
-                val isEmpty = config.keywordGroups.isEmpty()
-                binding.tvEmptyState.visibility = if (isEmpty) View.VISIBLE else View.GONE
-                binding.rvKeywordGroups.visibility = if (isEmpty) View.GONE else View.VISIBLE
-                adapter.submitList(config.keywordGroups)
+            viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+                viewModel.keywordBlockerConfig.collectLatest { config ->
+                    val isEmpty = config.keywordGroups.isEmpty()
+                    binding.tvEmptyState.visibility = if (isEmpty) View.VISIBLE else View.GONE
+                    binding.rvKeywordGroups.visibility = if (isEmpty) View.GONE else View.VISIBLE
+                    adapter.submitList(config.keywordGroups)
             }
         }
     }

--- a/app/src/main/java/neth/iecal/curbox/ui/fragments/main/reducers/blockertools/keywordBlocker/KeywordBlockerViewModel.kt
+++ b/app/src/main/java/neth/iecal/curbox/ui/fragments/main/reducers/blockertools/keywordBlocker/KeywordBlockerViewModel.kt
@@ -9,6 +9,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import neth.iecal.curbox.data.db.AppDatabase
@@ -28,6 +29,14 @@ class KeywordBlockerViewModel(application: Application) : AndroidViewModel(appli
 
     private val _keywordBlockerConfig = MutableStateFlow(KeywordBlocker())
     val keywordBlockerConfig: StateFlow<KeywordBlocker> = _keywordBlockerConfig
+
+    init {
+        viewModelScope.launch {
+            dataStoreManager.settings.collectLatest { settings ->
+                _keywordBlockerConfig.value = settings.keywordBlockerConfig
+            }
+        }
+    }
 
     var currentUsageConfig = AppUsageConfig()
     var currentTimeConfig = AppTimeConfig()
@@ -126,4 +135,5 @@ class KeywordBlockerViewModel(application: Application) : AndroidViewModel(appli
             config.copy(keywordGroups = groups)
         }
     }
+}
 }


### PR DESCRIPTION
Fix a bug where, after creating a keyword group for the first time after app installation, it is not shown unless the user exits the keyword blocker page and re enters. now it appears immediately after creation