### PR TITLE
Add minimum character setting for intent unlock

### DIFF
--- a/app/src/main/java/neth/iecal/curbox/data/models/WarningScreenConfig.kt
+++ b/app/src/main/java/neth/iecal/curbox/data/models/WarningScreenConfig.kt
@@ -17,5 +17,6 @@ data class AppBlockerWarningScreenConfig(
     val isTypingRequirementEnabled: Boolean = false,
     val typingSentence: String = "",
     val isIntentRequirementEnabled: Boolean = false,
+    val minIntentLength: Int = 1,
     var isOnOpenConfig: Boolean = false,
 )

--- a/app/src/main/java/neth/iecal/curbox/ui/activity/WarningActivity.kt
+++ b/app/src/main/java/neth/iecal/curbox/ui/activity/WarningActivity.kt
@@ -145,8 +145,19 @@ class WarningActivity : AppCompatActivity() {
                                 button.isEnabled = false
                                 button.setText(R.string.proceed)
 
+                                val minLength = warningScreenConfig.minIntentLength.coerceAtLeast(1)
                                 binding.intentInputEdit.doAfterTextChanged { s ->
-                                    button.isEnabled = s?.toString()?.trim()?.isNotEmpty() == true
+                                    val length = s?.toString()?.trim()?.length ?: 0
+                                    button.isEnabled = length >= minLength
+                                    if (length < minLength) {
+                                        binding.intentInputLayout.helperText = getString(
+                                            R.string.warning_intent_chars_needed,
+                                            minLength,
+                                            minLength - length
+                                        )
+                                    } else {
+                                        binding.intentInputLayout.helperText = null
+                                    }
                                 }
                             } else if (warningScreenConfig.isTypingRequirementEnabled) {
                                 binding.typingTargetSentence.visibility = View.VISIBLE
@@ -225,6 +236,9 @@ class WarningActivity : AppCompatActivity() {
 
             if (warningScreenConfig.isIntentRequirementEnabled) {
                 val intentText = binding.intentInputEdit.text.toString().trim()
+                if (intentText.length < warningScreenConfig.minIntentLength.coerceAtLeast(1)) {
+                    return@setOnClickListener
+                }
                 val pkg = targetId
                 val time = binding.minsPicker.getValue() * 60_000L
                 

--- a/app/src/main/java/neth/iecal/curbox/ui/activity/WarningActivity.kt
+++ b/app/src/main/java/neth/iecal/curbox/ui/activity/WarningActivity.kt
@@ -146,19 +146,23 @@ class WarningActivity : AppCompatActivity() {
                                 button.setText(R.string.proceed)
 
                                 val minLength = warningScreenConfig.minIntentLength.coerceAtLeast(1)
-                                binding.intentInputEdit.doAfterTextChanged { s ->
-                                    val length = s?.toString()?.trim()?.length ?: 0
+                                fun updateIntentInputState(length: Int) {
                                     button.isEnabled = length >= minLength
-                                    if (length < minLength) {
-                                        binding.intentInputLayout.helperText = getString(
-                                            R.string.warning_intent_chars_needed,
+                                    binding.intentInputLayout.helperText = if (length < minLength) {
+                                        resources.getQuantityString(
+                                            R.plurals.warning_intent_chars_needed,
+                                            minLength,
                                             minLength,
                                             minLength - length
                                         )
                                     } else {
-                                        binding.intentInputLayout.helperText = null
+                                        null
                                     }
                                 }
+                                binding.intentInputEdit.doAfterTextChanged { s ->
+                                    updateIntentInputState(s?.toString()?.trim()?.length ?: 0)
+                                }
+                                updateIntentInputState(binding.intentInputEdit.text.toString().trim().length)
                             } else if (warningScreenConfig.isTypingRequirementEnabled) {
                                 binding.typingTargetSentence.visibility = View.VISIBLE
                                 binding.typingTargetSentence.text = getString(R.string.warning_typing_quote, warningScreenConfig.typingSentence)

--- a/app/src/main/java/neth/iecal/curbox/ui/fragments/main/reducers/blockertools/shared/WarningConfigFragment.kt
+++ b/app/src/main/java/neth/iecal/curbox/ui/fragments/main/reducers/blockertools/shared/WarningConfigFragment.kt
@@ -163,8 +163,11 @@ class WarningConfigFragment : Fragment() {
         binding.typingSentenceEdit.setText(config.typingSentence)
 
         binding.intentMinLengthSlider.value = config.minIntentLength.toFloat().coerceIn(1f, 100f)
-        binding.intentMinLengthTitle.text =
-            getString(R.string.warning_intent_min_length, binding.intentMinLengthSlider.value.toInt())
+        binding.intentMinLengthTitle.text = resources.getQuantityString(
+            R.plurals.warning_intent_min_length,
+            binding.intentMinLengthSlider.value.toInt(),
+            binding.intentMinLengthSlider.value.toInt()
+        )
 
         binding.fixedTimeSlider.value = (config.timeInterval / 60000).toFloat().coerceIn(1f, 120f)
         binding.timingTitle.text = getString(R.string.warning_fixed_unlock_duration, binding.fixedTimeSlider.value.toInt())
@@ -254,7 +257,11 @@ class WarningConfigFragment : Fragment() {
         }
 
         binding.intentMinLengthSlider.addOnChangeListener { _, value, _ ->
-            binding.intentMinLengthTitle.text = getString(R.string.warning_intent_min_length, value.toInt())
+            binding.intentMinLengthTitle.text = resources.getQuantityString(
+                R.plurals.warning_intent_min_length,
+                value.toInt(),
+                value.toInt()
+            )
         }
 
         binding.advancedSettingsHeader.setOnClickListener {

--- a/app/src/main/java/neth/iecal/curbox/ui/fragments/main/reducers/blockertools/shared/WarningConfigFragment.kt
+++ b/app/src/main/java/neth/iecal/curbox/ui/fragments/main/reducers/blockertools/shared/WarningConfigFragment.kt
@@ -162,6 +162,10 @@ class WarningConfigFragment : Fragment() {
         
         binding.typingSentenceEdit.setText(config.typingSentence)
 
+        binding.intentMinLengthSlider.value = config.minIntentLength.toFloat().coerceIn(1f, 100f)
+        binding.intentMinLengthTitle.text =
+            getString(R.string.warning_intent_min_length, binding.intentMinLengthSlider.value.toInt())
+
         binding.fixedTimeSlider.value = (config.timeInterval / 60000).toFloat().coerceIn(1f, 120f)
         binding.timingTitle.text = getString(R.string.warning_fixed_unlock_duration, binding.fixedTimeSlider.value.toInt())
 
@@ -247,6 +251,10 @@ class WarningConfigFragment : Fragment() {
 
         binding.proceedWindowSlider.addOnChangeListener { _, value, _ ->
             binding.proceedWindowTitle.text = getString(R.string.warning_time_window, value.toInt())
+        }
+
+        binding.intentMinLengthSlider.addOnChangeListener { _, value, _ ->
+            binding.intentMinLengthTitle.text = getString(R.string.warning_intent_min_length, value.toInt())
         }
 
         binding.advancedSettingsHeader.setOnClickListener {
@@ -337,6 +345,7 @@ class WarningConfigFragment : Fragment() {
                 isTypingRequirementEnabled = isTypingRequirementEnabled,
                 typingSentence = binding.typingSentenceEdit.text.toString(),
                 isIntentRequirementEnabled = isIntentRequirementEnabled,
+                minIntentLength = binding.intentMinLengthSlider.value.toInt(),
                 proceedDelayInSecs = binding.proceedDelaySlider.value.toInt(),
                 vibrateAndIncBrightness = binding.switchVibrateBrightness.isChecked,
                 proceedLimitEnabled = binding.proceedLimitSwitch.isChecked,
@@ -403,6 +412,7 @@ class WarningConfigFragment : Fragment() {
             
             qrSetupContainer.visibility = if (challengeIndex == 1 && secondaryIndex == 0) View.VISIBLE else View.GONE
             typingSetupContainer.visibility = if (challengeIndex == 1 && secondaryIndex == 1) View.VISIBLE else View.GONE
+            intentSetupContainer.visibility = if (challengeIndex == 1 && secondaryIndex == 2) View.VISIBLE else View.GONE
         }
     }
     

--- a/app/src/main/java/neth/iecal/curbox/utils/RestrictionComparator.kt
+++ b/app/src/main/java/neth/iecal/curbox/utils/RestrictionComparator.kt
@@ -263,9 +263,14 @@ object RestrictionComparator {
         }
         val typingOk = !o.isTypingRequirementEnabled || n.isTypingRequirementEnabled
         val intentOk = !o.isIntentRequirementEnabled || n.isIntentRequirementEnabled
+        val intentMinLengthOk = when {
+            !o.isIntentRequirementEnabled || !n.isIntentRequirementEnabled -> true
+            else -> n.minIntentLength >= o.minIntentLength
+        }
 
         return cooldownOk && dynamicIntervalOk && proceedDisabledOk && dialogHiddenOk &&
-            proceedDelayOk && vibrateOk && proceedLimitOk && qrOk && typingOk && intentOk
+            proceedDelayOk && vibrateOk && proceedLimitOk && qrOk && typingOk && intentOk &&
+            intentMinLengthOk
     }
 
     private inline fun <reified T> parse(json: String): T? =

--- a/app/src/main/java/neth/iecal/curbox/utils/RestrictionComparator.kt
+++ b/app/src/main/java/neth/iecal/curbox/utils/RestrictionComparator.kt
@@ -265,7 +265,7 @@ object RestrictionComparator {
         val intentOk = !o.isIntentRequirementEnabled || n.isIntentRequirementEnabled
         val intentMinLengthOk = when {
             !o.isIntentRequirementEnabled || !n.isIntentRequirementEnabled -> true
-            else -> n.minIntentLength >= o.minIntentLength
+            else -> n.minIntentLength.coerceAtLeast(1) >= o.minIntentLength.coerceAtLeast(1)
         }
 
         return cooldownOk && dynamicIntervalOk && proceedDisabledOk && dialogHiddenOk &&

--- a/app/src/main/res/layout/fragment_warning_config.xml
+++ b/app/src/main/res/layout/fragment_warning_config.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/main_content_container"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
@@ -267,7 +268,7 @@
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_marginTop="8dp"
-                    android:text="@string/warning_intent_min_length" />
+                    tools:text="Minimum character: 1" />
 
                 <com.google.android.material.slider.Slider
                     android:id="@+id/intent_min_length_slider"

--- a/app/src/main/res/layout/fragment_warning_config.xml
+++ b/app/src/main/res/layout/fragment_warning_config.xml
@@ -235,6 +235,53 @@
         </com.google.android.material.card.MaterialCardView>
 
         <com.google.android.material.card.MaterialCardView
+            android:id="@+id/intent_setup_container"
+            style="@style/Widget.Material3.CardView.Outlined"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="16dp"
+            android:visibility="gone">
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="vertical"
+                android:padding="16dp">
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/label_intent_auth"
+                    style="@style/TextAppearance.Material3.TitleMedium" />
+
+                <TextView
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="8dp"
+                    android:text="@string/label_intent_min_desc"
+                    style="@style/TextAppearance.Material3.BodyMedium" />
+
+                <TextView
+                    android:id="@+id/intent_min_length_title"
+                    style="@style/TextAppearance.Material3.BodyMedium"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="8dp"
+                    android:text="@string/warning_intent_min_length" />
+
+                <com.google.android.material.slider.Slider
+                    android:id="@+id/intent_min_length_slider"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:stepSize="1.0"
+                    android:value="1.0"
+                    android:valueFrom="1.0"
+                    android:valueTo="100.0" />
+
+            </LinearLayout>
+        </com.google.android.material.card.MaterialCardView>
+
+        <com.google.android.material.card.MaterialCardView
             style="@style/Widget.Material3.CardView.Outlined"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -402,8 +402,14 @@
     <string name="label_typing_desc">Enter the sentence the user must type exactly to bypass the block:</string>
     <string name="label_intent_auth">Intent unlock length</string>
     <string name="label_intent_min_desc">I choose how many characters someone must write before they can continue.</string>
-    <string name="warning_intent_min_length">Minimum characters: %1$d</string>
-    <string name="warning_intent_chars_needed">Write at least %1$d characters (%2$d more to go)</string>
+    <plurals name="warning_intent_min_length">
+        <item quantity="one">Minimum character: %1$d</item>
+        <item quantity="other">Minimum characters: %1$d</item>
+    </plurals>
+    <plurals name="warning_intent_chars_needed">
+        <item quantity="one">Write at least %1$d character (%2$d more to go)</item>
+        <item quantity="other">Write at least %1$d characters (%2$d more to go)</item>
+    </plurals>
     <string name="label_limit_unlock_frequency">Limit unlock frequency</string>
     <string name="label_allowed_proceeds">Allowed proceeds: 3</string>
     <string name="label_time_window">Time window: 60 mins</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -400,6 +400,10 @@
     <string name="label_configured_qr">Configured QR/Barcodes:</string>
     <string name="label_typing_auth">Typing Authentication</string>
     <string name="label_typing_desc">Enter the sentence the user must type exactly to bypass the block:</string>
+    <string name="label_intent_auth">Intent unlock length</string>
+    <string name="label_intent_min_desc">I choose how many characters someone must write before they can continue.</string>
+    <string name="warning_intent_min_length">Minimum characters: %1$d</string>
+    <string name="warning_intent_chars_needed">Write at least %1$d characters (%2$d more to go)</string>
     <string name="label_limit_unlock_frequency">Limit unlock frequency</string>
     <string name="label_allowed_proceeds">Allowed proceeds: 3</string>
     <string name="label_time_window">Time window: 60 mins</string>


### PR DESCRIPTION
## Summary
- Adds a configurable minimum character count for the intent unlock challenge on the warning screen
- Defaults to 1 character so existing groups keep the same behavior
- Shows helper text when the answer is still too short
- Treats lowering the minimum as weaker unlock friction under settings change delay

Closes #317

## Test plan
- [ ] CI passes (`assembleFdroidDebug`)
- [ ] Intent unlock with min 1: a single character enables Proceed
- [ ] Intent unlock with min 20: short text stays blocked, 20+ characters enables Proceed
- [ ] Slider value persists after saving warning config


Made with [Cursor](https://cursor.com)