### PR TITLE
Label the only warning screen button Okay when proceed is hidden

### DIFF
--- a/app/src/main/java/neth/iecal/curbox/ui/activity/WarningActivity.kt
+++ b/app/src/main/java/neth/iecal/curbox/ui/activity/WarningActivity.kt
@@ -122,6 +122,7 @@ class WarningActivity : AppCompatActivity() {
 
         if (warningScreenConfig.isProceedDisabled || isProceedLimitExceeded) {
             binding.btnProceed.visibility = View.GONE
+            binding.btnCancel.setText(R.string.okay)
             if (isProceedLimitExceeded) {
                 binding.proceedSeconds.visibility = View.VISIBLE
                 binding.proceedSeconds.text = getString(R.string.warning_proceed_limit_reached, warningScreenConfig.allowedProceeds, warningScreenConfig.proceedsTimeWindowMn, timeUntilNextProceedMn)


### PR DESCRIPTION
When the warning screen's proceed button is hidden (proceed disabled in the warning screen config, or the proceed limit is exhausted), the remaining button is the only way out of the warning screen. "Cancel" implied there was something to abort, so it now acknowledges the block instead.