### PR TITLE
Fix null-safe find() chaining so else-if scripts keep running

### DIFF
--- a/app/src/main/java/neth/iecal/curbox/blockers/uihider/script/Interpreter.kt
+++ b/app/src/main/java/neth/iecal/curbox/blockers/uihider/script/Interpreter.kt
@@ -209,6 +209,7 @@ class Interpreter(
     private fun evalMember(expr: Expr.Member, env: Environment): Any? {
         val target = evaluate(expr.target, env)
         return when (target) {
+            null -> null
             is ScriptNode -> target.prop(expr.name)
             is Map<*, *> -> {
                 if (!target.containsKey(expr.name)) throw ScriptError("unknown property '${expr.name}'", expr.line)
@@ -226,6 +227,7 @@ class Interpreter(
         // Method call: obj.method(...)
         if (callee is Expr.Member) {
             val target = evaluate(callee.target, env)
+            if (target == null) return null
             if (target is ScriptNode) return target.call(callee.name, args, named)
             throw ScriptError("cannot call '.${callee.name}()' on ${Values.typeName(target)}", expr.line)
         }

--- a/app/src/test/java/neth/iecal/curbox/blockers/uihider/script/ScriptLanguageTest.kt
+++ b/app/src/test/java/neth/iecal/curbox/blockers/uihider/script/ScriptLanguageTest.kt
@@ -88,6 +88,44 @@ class ScriptLanguageTest {
         assertEquals("ok\n", run(src).log.toString())
     }
 
+    @Test fun elseIfChainSelectsMatchingBranch() {
+        val src = """
+            if false { log("a") }
+            else if true { log("b") }
+            else { log("c") }
+        """.trimIndent()
+        assertEquals("b\n", run(src).log.toString())
+    }
+
+    // Reproduces #328: find() returning null used to throw on .visible and abort
+    // the script before later else-if arms (or later top-level ifs) could run.
+    @Test fun nullPropertyAccessDoesNotAbortElseIf() {
+        val src = """
+            x = null
+            if x.visible == true { log("first") }
+            else if true { log("second") }
+        """.trimIndent()
+        assertEquals("second\n", run(src).log.toString())
+    }
+
+    @Test fun nullPropertyAccessDoesNotAbortLaterIf() {
+        val src = """
+            x = null
+            if x.visible == true { log("first") }
+            if true { log("second") }
+        """.trimIndent()
+        assertEquals("second\n", run(src).log.toString())
+    }
+
+    @Test fun nullMethodCallIsNoOp() {
+        val src = """
+            x = null
+            x.click()
+            log("ok")
+        """.trimIndent()
+        assertEquals("ok\n", run(src).log.toString())
+    }
+
     @Test fun stringConcatAndBuiltins() {
         assertEquals("v=3\n", run("""log("v=" + 3)""").log.toString())
         assertEquals("7\n", run("log(max(3, 7, 2))").log.toString())


### PR DESCRIPTION
## Summary
- Root cause of #328 was not broken `else if` parsing: `find()` returning `null` made `.visible` throw `ScriptError` and abort the script before later branches ran.
- Property and method access on `null` now returns `null` (optional-chaining style) in the UiHider interpreter.
- Added `ScriptLanguageTest` coverage for `else if` chains, the reporter's null-`.visible` pattern, later top-level `if`s, and null method calls.

Closes #328

## Test plan
- [x] `./gradlew testFdroidDebugUnitTest --tests neth.iecal.curbox.blockers.uihider.script.ScriptLanguageTest` (18 tests, 0 failures)
- [ ] Optional device smoke: UI hider script with `if find(...).visible ... else if find(...).visible ...` where the first node is missing


Made with [Cursor](https://cursor.com)