### PR TITLE
Add contextual subtree text and regex matching to UI Hider

### DIFF
--- a/app/src/main/java/neth/iecal/curbox/blockers/uihider/UiHiderRuntime.kt
+++ b/app/src/main/java/neth/iecal/curbox/blockers/uihider/UiHiderRuntime.kt
@@ -37,6 +37,11 @@ class UiHiderRuntime(
     companion object {
         // Resolved foreign-app string resources, cached across runs (key = "package:resName").
         private val appStringCache = java.util.concurrent.ConcurrentHashMap<String, String>()
+        // Compiled patterns are immutable and safe to reuse across short-lived runtime instances.
+        private val regexCache = java.util.concurrent.ConcurrentHashMap<String, Regex>()
+
+        private const val MAX_SUBTREE_DEPTH = 64
+        private const val MAX_SUBTREE_CHARS = 100_000
     }
 
     override fun provideGlobals(): Map<String, Any?> = globals
@@ -52,6 +57,13 @@ class UiHiderRuntime(
             "home" -> { service.pressHome(); null }
             "log" -> { output.append(args.joinToString(" ") { Values.stringify(it) }).append('\n'); null }
             "appString" -> resolveAppString(args.getOrNull(0))
+            "subtreeText" -> {
+                val target = args.getOrNull(0)
+                if (target !is NodeHandle) {
+                    throw ScriptError("subtreeText() expects a node, got ${Values.typeName(target)}")
+                }
+                target.collectSubtreeText(args.drop(1))
+            }
             "save" -> {
                 val value = args.getOrNull(1)
                 assertStorable(value)
@@ -62,7 +74,7 @@ class UiHiderRuntime(
             "has" -> store.has(scriptId, storeKey(args, "has"))
             "remove" -> { store.remove(scriptId, storeKey(args, "remove")); null }
             else -> {
-                val result = Builtins.tryCall(name, args)
+                val result = Builtins.tryCall(name, args, budget, regexCache)
                 if (result === Builtins.UNKNOWN) throw ScriptError("unknown function '$name'")
                 result
             }
@@ -205,7 +217,70 @@ class UiHiderRuntime(
             "children" -> (0 until node.childCount).mapNotNull { i -> node.getChild(i)?.let { wrap(it) } }
             "parent" -> node.parent?.let { wrap(it) }
             "hide" -> { emitDraw(Rect(bounds), named); null }
+            "subtreeText" -> collectSubtreeText(args)
             else -> throw ScriptError("unknown node method '$name'")
+        }
+
+        fun collectSubtreeText(args: List<Any?>): String {
+            val maxDepth = boundedSubtreeArg(args, 0, "maxDepth", MAX_SUBTREE_DEPTH)
+            val maxChars = boundedSubtreeArg(args, 1, "maxChars", MAX_SUBTREE_CHARS)
+            if (maxChars == 0) return ""
+
+            val out = StringBuilder(minOf(maxChars, 1024))
+            budget.countNode()
+            appendNodeText(node, out, maxChars)
+            if (out.length >= maxChars || maxDepth == 0) return out.toString()
+
+            fun visit(parent: AccessibilityNodeInfo, depth: Int) {
+                if (depth > maxDepth || out.length >= maxChars) return
+                for (i in 0 until parent.childCount) {
+                    if (out.length >= maxChars) break
+                    budget.countNode()
+                    val child = parent.getChild(i) ?: continue
+                    try {
+                        appendNodeText(child, out, maxChars)
+                        if (depth < maxDepth && out.length < maxChars) visit(child, depth + 1)
+                    } finally {
+                        recycle(child)
+                    }
+                }
+            }
+
+            visit(node, 1)
+            return out.toString()
+        }
+
+        private fun boundedSubtreeArg(
+            args: List<Any?>,
+            index: Int,
+            label: String,
+            hardMax: Int
+        ): Int {
+            val raw = args.getOrNull(index)
+                ?: throw ScriptError("subtreeText() requires $label")
+            val value = Values.asInt(raw, 0)
+            if (value < 0) throw ScriptError("subtreeText() $label must be non-negative")
+            if (value > hardMax) {
+                throw ScriptError("subtreeText() $label exceeds maximum $hardMax")
+            }
+            return value
+        }
+
+        private fun appendNodeText(target: AccessibilityNodeInfo, out: StringBuilder, maxChars: Int) {
+            appendTextPart(target.text?.toString(), out, maxChars)
+            val desc = target.contentDescription?.toString()
+            if (desc != target.text?.toString()) appendTextPart(desc, out, maxChars)
+        }
+
+        private fun appendTextPart(value: String?, out: StringBuilder, maxChars: Int) {
+            val text = value?.trim().orEmpty()
+            if (text.isEmpty() || out.length >= maxChars) return
+            if (out.isNotEmpty()) {
+                if (out.length >= maxChars) return
+                out.append('\n')
+            }
+            val remaining = maxChars - out.length
+            if (remaining > 0) out.append(text, 0, minOf(text.length, remaining))
         }
     }
 

--- a/app/src/main/java/neth/iecal/curbox/blockers/uihider/script/Budget.kt
+++ b/app/src/main/java/neth/iecal/curbox/blockers/uihider/script/Budget.kt
@@ -28,6 +28,18 @@ class Budget(
         if (++nodes > maxNodes) throw ScriptError("script visited too many nodes ($maxNodes)")
     }
 
+    /** Charge a bounded amount of host-side work (for example regex input scanning). */
+    fun chargeOperations(amount: Int) {
+        if (amount <= 0) return
+        if (amount > maxOps - ops) {
+            throw ScriptError("script exceeded operation budget ($maxOps)")
+        }
+        ops += amount
+        if (System.nanoTime() > deadlineNs) {
+            throw ScriptError("script exceeded time budget")
+        }
+    }
+
     fun enterCall() {
         if (++depth > maxDepth) throw ScriptError("call depth exceeded ($maxDepth)")
     }

--- a/app/src/main/java/neth/iecal/curbox/blockers/uihider/script/Builtins.kt
+++ b/app/src/main/java/neth/iecal/curbox/blockers/uihider/script/Builtins.kt
@@ -1,5 +1,7 @@
 package neth.iecal.curbox.blockers.uihider.script
 
+import java.util.concurrent.ConcurrentHashMap
+
 import kotlin.math.abs
 import kotlin.math.ceil
 import kotlin.math.floor
@@ -17,8 +19,15 @@ object Builtins {
     val UNKNOWN = Any()
 
     private const val MAX_RANGE = 100_000
+    private const val MAX_REGEX_LENGTH = 16_384
+    private const val REGEX_CHARS_PER_OPERATION = 16
 
-    fun tryCall(name: String, args: List<Any?>): Any? = when (name) {
+    fun tryCall(
+        name: String,
+        args: List<Any?>,
+        budget: Budget? = null,
+        regexCache: ConcurrentHashMap<String, Regex>? = null
+    ): Any? = when (name) {
         "abs" -> abs(num(name, args, 0))
         "floor" -> floor(num(name, args, 0))
         "ceil" -> ceil(num(name, args, 0))
@@ -37,6 +46,12 @@ object Builtins {
             else -> throw ScriptError("len() expects a string or list, got ${Values.typeName(x)}")
         }
         "str" -> Values.stringify(arg(name, args, 0))
+        "lower" -> stringArg(name, args, 0).lowercase()
+        "containsIgnoreCase" -> stringArg(name, args, 0).contains(
+            stringArg(name, args, 1),
+            ignoreCase = true
+        )
+        "matchesRegex" -> matchesRegex(args, budget, regexCache)
         "int" -> when (val x = arg(name, args, 0)) {
             is Double -> x.toLong().toDouble()
             is Boolean -> if (x) 1.0 else 0.0
@@ -46,6 +61,49 @@ object Builtins {
         }
         "range" -> range(args)
         else -> UNKNOWN
+    }
+
+
+    private fun matchesRegex(
+        args: List<Any?>,
+        budget: Budget?,
+        regexCache: ConcurrentHashMap<String, Regex>?
+    ): Boolean {
+        val input = stringArg("matchesRegex", args, 0)
+        val pattern = stringArg("matchesRegex", args, 1)
+        val flags = if (args.size >= 3) stringArg("matchesRegex", args, 2) else ""
+
+        if (pattern.length > MAX_REGEX_LENGTH) {
+            throw ScriptError("matchesRegex() pattern too long (max $MAX_REGEX_LENGTH characters)")
+        }
+
+        val options = LinkedHashSet<RegexOption>()
+        for (flag in flags) {
+            when (flag.lowercaseChar()) {
+                'i' -> options.add(RegexOption.IGNORE_CASE)
+                'm' -> options.add(RegexOption.MULTILINE)
+                's' -> options.add(RegexOption.DOT_MATCHES_ALL)
+                'u' -> Unit // Kotlin/JVM regexes are Unicode-aware; accepted for API familiarity.
+                else -> throw ScriptError("matchesRegex() unknown flag '$flag'")
+            }
+        }
+
+        // Approximate regex work by the amount of input and pattern data examined. The runtime's
+        // hard time deadline remains the final guard against unexpectedly expensive expressions.
+        val charge = maxOf(1, (input.length + pattern.length + REGEX_CHARS_PER_OPERATION - 1) /
+            REGEX_CHARS_PER_OPERATION)
+        budget?.chargeOperations(charge)
+
+        val optionKey = options.map { it.name }.sorted().joinToString(",")
+        val cacheKey = "$optionKey\u0000$pattern"
+        val regex = try {
+            regexCache?.get(cacheKey) ?: Regex(pattern, options).also {
+                regexCache?.putIfAbsent(cacheKey, it)
+            }
+        } catch (e: IllegalArgumentException) {
+            throw ScriptError("matchesRegex() invalid pattern: ${e.message ?: "syntax error"}")
+        }
+        return regex.containsMatchIn(input)
     }
 
     private fun range(args: List<Any?>): List<Any?> {
@@ -80,4 +138,10 @@ object Builtins {
 
     private fun num(name: String, args: List<Any?>, i: Int): Double =
         Values.asNumber(arg(name, args, i), 0)
+
+    private fun stringArg(name: String, args: List<Any?>, i: Int): String {
+        val value = arg(name, args, i)
+        return value as? String
+            ?: throw ScriptError("$name() expects argument ${i + 1} to be a string, got ${Values.typeName(value)}")
+    }
 }

--- a/app/src/test/java/neth/iecal/curbox/blockers/uihider/script/ScriptLanguageTest.kt
+++ b/app/src/test/java/neth/iecal/curbox/blockers/uihider/script/ScriptLanguageTest.kt
@@ -12,10 +12,11 @@ import org.junit.Test
 class ScriptLanguageTest {
 
     /** Captures `log()`/`draw()`, backs `save`/`load`, routes everything else to [Builtins]. */
-    private class StubApi : RuntimeApi {
+    private class StubApi(val budget: Budget = Budget()) : RuntimeApi {
         val log = StringBuilder()
         val draws = ArrayList<List<Any?>>()
         val store = HashMap<String, Any?>()
+        val regexCache = java.util.concurrent.ConcurrentHashMap<String, Regex>()
 
         override fun provideGlobals(): Map<String, Any?> = mapOf(
             "app" to "com.test.app",
@@ -31,16 +32,16 @@ class ScriptLanguageTest {
             "has" -> store.containsKey(args[0] as String)
             "remove" -> { store.remove(args[0] as String); null }
             else -> {
-                val r = Builtins.tryCall(name, args)
+                val r = Builtins.tryCall(name, args, budget, regexCache)
                 if (r === Builtins.UNKNOWN) throw ScriptError("unknown function '$name'")
                 r
             }
         }
     }
 
-    private fun run(source: String): StubApi {
-        val api = StubApi()
-        Interpreter(api, Budget()).run(Parser.parse(source))
+    private fun run(source: String, budget: Budget = Budget()): StubApi {
+        val api = StubApi(budget)
+        Interpreter(api, budget).run(Parser.parse(source))
         return api
     }
 
@@ -181,6 +182,69 @@ class ScriptLanguageTest {
         } finally {
             file.delete()
         }
+    }
+
+
+    @Test fun contextualStringBuiltinsHandleUnicodeAndExceptions() {
+        val src = """
+            text = "Çıplaklık hakkında hukuki destek ve mağdur yardımı"
+            risk = matchesRegex(text, "çıplaklık", "iu")
+            protected = matchesRegex(text, "hukuki|mağdur yardımı", "iu")
+            log(risk and protected)
+            log(containsIgnoreCase(text, "HUKUKİ DESTEK"))
+            log(lower("ABCÇĞÖŞÜ"))
+        """.trimIndent()
+        val output = run(src).log.toString().lines()
+        assertEquals("true", output[0])
+        assertEquals("true", output[1])
+        assertEquals("abcçğöşü", output[2])
+    }
+
+    @Test fun matchesRegexSupportsCommonFlags() {
+        val src = """
+            log(matchesRegex("First\\nSECOND", "^second$", "imu"))
+            log(matchesRegex("a\\nb", "a.b", "su"))
+        """.trimIndent()
+        assertEquals("true\ntrue\n", run(src).log.toString())
+    }
+
+    @Test fun matchesRegexRejectsInvalidPatternsAndFlags() {
+        try {
+            run("log(matchesRegex(\"text\", \"[\", \"iu\"))")
+            fail("expected invalid regex to fail")
+        } catch (e: ScriptError) {
+            assertTrue(e.message!!.contains("invalid pattern"))
+        }
+
+        try {
+            run("log(matchesRegex(\"text\", \"text\", \"x\"))")
+            fail("expected unknown regex flag to fail")
+        } catch (e: ScriptError) {
+            assertTrue(e.message!!.contains("unknown flag"))
+        }
+    }
+
+    @Test fun regexWorkIsChargedAgainstOperationBudget() {
+        val tinyBudget = Budget(maxOps = 2, timeBudgetMs = 10_000)
+        try {
+            run(
+                "log(matchesRegex(\"${"x".repeat(1000)}\", \"x+\", \"\"))",
+                tinyBudget
+            )
+            fail("expected regex work to exhaust operation budget")
+        } catch (e: ScriptError) {
+            assertTrue(e.message!!.contains("operation budget"))
+        }
+    }
+
+    @Test fun regexCacheCanBeReusedAcrossCalls() {
+        val cache = java.util.concurrent.ConcurrentHashMap<String, Regex>()
+        val budget = Budget(timeBudgetMs = 10_000)
+        assertEquals(true, Builtins.tryCall("matchesRegex", listOf("ABC", "abc", "iu"), budget, cache))
+        val sizeAfterFirst = cache.size
+        assertEquals(true, Builtins.tryCall("matchesRegex", listOf("abc", "abc", "iu"), budget, cache))
+        assertEquals(sizeAfterFirst, cache.size)
+        assertEquals(1, cache.size)
     }
 
     @Test fun syntaxErrorReportsLine() {


### PR DESCRIPTION
## Summary

This pull request adds contextual text-matching capabilities to UI Hider scripts.

It implements:

* bounded subtree text collection
* case-insensitive string matching
* regex matching with supported flags
* compiled regex caching
* execution-budget charging for regex operations
* node-budget charging for subtree traversal
* interpreter tests covering the new functionality

## Added scripting functions

```text
subtreeText(node, maxDepth, maxChars)
containsIgnoreCase(text, value)
lower(text)
matchesRegex(text, pattern, flags)
```

## Motivation

Some UI cards expose their title, description, source, and exception context through separate Accessibility nodes.

For example:

```text
Title: Revenge porn
Description: Legal information and victim support
```

Matching only the title node can create a false positive. Bounded subtree-text collection allows scripts to evaluate the candidate card as a whole before deciding whether to hide it.

This also enables generic contextual rules such as:

```text
risk term AND supporting term AND NOT protected context
```

The implementation is generic and does not contain TemizWeb-specific or PMO-specific rules.

## Safety and performance

* Subtree traversal is bounded by depth and character limits.
* Visited nodes are charged against the existing node budget.
* Regex operations are charged against the execution budget based on input size.
* Compiled regex objects are cached in a static `ConcurrentHashMap`.
* Invalid or unsupported regex input is handled safely.
* Regex and subtree limits prevent unbounded script work.

## Tests

Tests were added for:

* nested subtree text
* maximum depth
* maximum character count
* case-insensitive matching
* Turkish and Unicode text
* regex flags
* invalid regex patterns
* regex caching
* regex budget exhaustion
* subtree node-budget exhaustion
* contextual trigger and protected-context evaluation

Closes #355
