### PR TITLE
Add support for nfc activation

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -10,6 +10,10 @@
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
 <uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS"/>
     <uses-permission android:name="android.permission.VIBRATE" />
+    <uses-permission android:name="android.permission.NFC" />
+    <uses-feature
+        android:name="android.hardware.nfc"
+        android:required="false" />
     <uses-permission android:name="android.permission.ACCESS_NOTIFICATION_POLICY" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_SPECIAL_USE" />
@@ -59,6 +63,20 @@
         <activity
             android:name=".ui.activity.SelectAppsActivity"
             android:exported="false" />
+
+        <activity
+            android:name=".nfc.NfcTriggerActivity"
+            android:exported="true"
+            android:excludeFromRecents="true"
+            android:launchMode="singleTop"
+            android:noHistory="true"
+            android:theme="@android:style/Theme.Translucent.NoTitleBar">
+            <intent-filter>
+                <action android:name="android.nfc.action.NDEF_DISCOVERED" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <data android:scheme="curbox" android:host="focus" />
+            </intent-filter>
+        </activity>
 
         <activity
             android:name=".ui.activity.CrashLogActivity"

--- a/app/src/main/java/neth/iecal/curbox/data/models/WarningScreenConfig.kt
+++ b/app/src/main/java/neth/iecal/curbox/data/models/WarningScreenConfig.kt
@@ -14,6 +14,8 @@ data class AppBlockerWarningScreenConfig(
     val proceedsTimeWindowMn: Int = 60,
     val isQrUnlockRequirementEnabled: Boolean = false,
     val qrKeys: Map<String,Long> = mapOf(), // qr code content -> Duration of unlock (-1 if dynamic timing)
+    val isNfcUnlockRequirementEnabled: Boolean = false,
+    val nfcKeys: Map<String,Long> = mapOf(), // nfc tag key (written UUID or UID) -> Duration of unlock (-1 if dynamic timing)
     val isTypingRequirementEnabled: Boolean = false,
     val typingSentence: String = "",
     val isIntentRequirementEnabled: Boolean = false,

--- a/app/src/main/java/neth/iecal/curbox/nfc/NfcFocusHandler.kt
+++ b/app/src/main/java/neth/iecal/curbox/nfc/NfcFocusHandler.kt
@@ -1,0 +1,193 @@
+package neth.iecal.curbox.nfc
+
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import android.util.Log
+import kotlinx.coroutines.flow.first
+import neth.iecal.curbox.blockers.FocusModeBlocker
+import neth.iecal.curbox.data.db.AppDatabase
+import neth.iecal.curbox.data.db.FocusStatsEntity
+import neth.iecal.curbox.utils.DataStoreManager
+
+/**
+ * Turns an NFC tag into a focus-mode change.
+ *
+ * Tags carry an NDEF URI in the form:
+ *   curbox://focus/<action>[?group=<groupId>&mins=<minutes>]
+ * where <action> is one of: toggle, start, stop.
+ *
+ * Writes state through DataStoreManager and fires the focus refresh broadcast, exactly like the
+ * in-app and API paths, so NFC-driven changes stay consistent with them.
+ */
+object NfcFocusHandler {
+
+    private const val TAG = "NfcFocusHandler"
+
+    const val SCHEME = "curbox"
+    const val HOST = "focus"
+
+    private const val PREFS = "AppPreferences"
+    private const val KEY_LAST_GROUP = "lastFocusGroupId"
+    private const val KEY_LAST_DURATION = "lastFocusDuration"
+    private const val KEY_LAST_WRITE = "lastFocusTagWriteAt"
+    private const val WRITE_DEBOUNCE_MS = 4000L
+
+    /** Result of handling a tag, used to build a user-facing message. */
+    sealed class Result {
+        data class Started(val groupName: String, val minutes: Int) : Result()
+        object Stopped : Result()
+        object NoGroup : Result()
+        object NotExitable : Result()
+        object Invalid : Result()
+        object Debounced : Result()
+    }
+
+    /** Records that a focus tag was just written, so an immediate re-scan is debounced. */
+    fun markTagWritten(context: Context) {
+        context.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
+            .edit().putLong(KEY_LAST_WRITE, System.currentTimeMillis()).apply()
+    }
+
+    /** The action + parameters decoded from a tag URI. */
+    data class Request(val action: String, val groupId: String?, val minutes: Int?)
+
+    /** True if the URI is one this handler understands. */
+    fun matches(uri: Uri?): Boolean =
+        uri != null && uri.scheme == SCHEME && uri.host == HOST
+
+    /**
+     * Parses a `curbox://focus/<action>[?group=&mins=]` URI into a [Request], or null if it isn't a
+     * Curbox focus URI.
+     */
+    fun parse(raw: String?): Request? {
+        if (raw == null) return null
+        val uri = try { java.net.URI(raw) } catch (e: Exception) { return null }
+        if (uri.scheme != SCHEME || uri.host != HOST) return null
+
+        val query = parseQuery(uri.rawQuery)
+        val action = uri.path?.trim('/')?.substringBefore('/')?.lowercase()?.ifBlank { null }
+            ?: query["action"]?.lowercase()
+            ?: "toggle"
+        return Request(action, query["group"], query["mins"]?.toIntOrNull())
+    }
+
+    private fun parseQuery(rawQuery: String?): Map<String, String> {
+        if (rawQuery.isNullOrEmpty()) return emptyMap()
+        return rawQuery.split('&').mapNotNull { part ->
+            val idx = part.indexOf('=')
+            if (idx <= 0) return@mapNotNull null
+            val key = decode(part.substring(0, idx))
+            val value = decode(part.substring(idx + 1))
+            key to value
+        }.toMap()
+    }
+
+    private fun decode(s: String): String =
+        try { java.net.URLDecoder.decode(s, "UTF-8") } catch (e: Exception) { s }
+
+    suspend fun handle(context: Context, uri: Uri?): Result {
+        val request = parse(uri.toString()) ?: return Result.Invalid
+        val app = context.applicationContext
+
+        val lastWrite = app.getSharedPreferences(PREFS, Context.MODE_PRIVATE).getLong(KEY_LAST_WRITE, 0L)
+        if (System.currentTimeMillis() - lastWrite < WRITE_DEBOUNCE_MS) return Result.Debounced
+
+        val dataStore = DataStoreManager(app)
+        val settings = dataStore.settings.first()
+
+        return try {
+            when (request.action) {
+                "stop" -> stop(app, dataStore, settings)
+                "start" -> start(app, dataStore, settings, request.groupId, request.minutes)
+                "toggle" ->
+                    if (isFocusActive(settings)) stop(app, dataStore, settings)
+                    else start(app, dataStore, settings, request.groupId, request.minutes)
+                else -> Result.Invalid
+            }
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to handle NFC focus action '${request.action}'", e)
+            Result.Invalid
+        }
+    }
+
+    private fun isFocusActive(settings: neth.iecal.curbox.data.models.Settings): Boolean {
+        val (id, endTime) = settings.activeManualFocusGroupId
+        return id != null && endTime > System.currentTimeMillis()
+    }
+
+    private fun isNonExitableActive(settings: neth.iecal.curbox.data.models.Settings): Boolean {
+        val (activeId, endTime) = settings.activeManualFocusGroupId
+        if (activeId == null || endTime <= System.currentTimeMillis()) return false
+        val activeGroup = settings.manualFocusGroups.firstOrNull { it.groupId == activeId }
+        return activeGroup != null && !activeGroup.exitable
+    }
+
+    private suspend fun start(
+        context: Context,
+        dataStore: DataStoreManager,
+        settings: neth.iecal.curbox.data.models.Settings,
+        groupId: String?,
+        minutes: Int?
+    ): Result {
+        if (isNonExitableActive(settings)) return Result.NotExitable
+
+        val prefs = context.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
+
+        // Resolve group: explicit tag value -> last used -> the only group if just one exists
+        val group = when {
+            groupId != null -> settings.manualFocusGroups.firstOrNull { it.groupId == groupId }
+            else -> settings.manualFocusGroups.firstOrNull {
+                it.groupId == prefs.getString(KEY_LAST_GROUP, null)
+            } ?: settings.manualFocusGroups.singleOrNull()
+        } ?: return Result.NoGroup
+
+        val mins = (minutes ?: prefs.getInt(KEY_LAST_DURATION, 25)).coerceAtLeast(1)
+        val durationMs = mins * 60_000L
+        val now = System.currentTimeMillis()
+
+        val statsDao = AppDatabase.getInstance(context).focusStatsDao()
+        statsDao.insert(
+            FocusStatsEntity(
+                groupId = group.groupId,
+                startTimeInMillis = now,
+                estimatedEndTimeInMillis = now + durationMs,
+                actualEndTimeInMillis = 0L,
+                status = 0
+            )
+        )
+        dataStore.setManualFocusStateToActive(group.groupId, durationMs)
+        broadcast(context)
+
+        prefs.edit()
+            .putString(KEY_LAST_GROUP, group.groupId)
+            .putInt(KEY_LAST_DURATION, mins)
+            .apply()
+
+        return Result.Started(group.groupName, mins)
+    }
+
+    private suspend fun stop(
+        context: Context,
+        dataStore: DataStoreManager,
+        settings: neth.iecal.curbox.data.models.Settings
+    ): Result {
+        if (isNonExitableActive(settings)) return Result.NotExitable
+
+        val statsDao = AppDatabase.getInstance(context).focusStatsDao()
+        val now = System.currentTimeMillis()
+        for (session in statsDao.getRunningSessions()) {
+            val actEnd = if (session.estimatedEndTimeInMillis < now) session.estimatedEndTimeInMillis else now
+            statsDao.update(session.copy(status = 1, actualEndTimeInMillis = actEnd))
+        }
+        dataStore.setManualFocusStateToInactive()
+        broadcast(context)
+        return Result.Stopped
+    }
+
+    private fun broadcast(context: Context) {
+        context.sendBroadcast(
+            Intent(FocusModeBlocker.INTENT_ACTION_REFRESH_FOCUS_MODE).setPackage(context.packageName)
+        )
+    }
+}

--- a/app/src/main/java/neth/iecal/curbox/nfc/NfcTriggerActivity.kt
+++ b/app/src/main/java/neth/iecal/curbox/nfc/NfcTriggerActivity.kt
@@ -1,0 +1,93 @@
+package neth.iecal.curbox.nfc
+
+import android.app.Activity
+import android.content.Intent
+import android.net.Uri
+import android.nfc.NdefMessage
+import android.nfc.NdefRecord
+import android.nfc.NfcAdapter
+import android.os.Bundle
+import android.widget.Toast
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import neth.iecal.curbox.R
+
+/**
+ * Invisible activity launched when an NFC tag carrying a `curbox://focus/...` URI is scanned.
+ *
+ * It parses the tag, applies the focus change via [NfcFocusHandler] and shows a toast immediately.
+ */
+class NfcTriggerActivity : Activity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        handleIntent(intent)
+    }
+
+    override fun onNewIntent(intent: Intent) {
+        super.onNewIntent(intent)
+        handleIntent(intent)
+    }
+
+    private fun handleIntent(intent: Intent?) {
+        val uri = extractUri(intent)
+        if (!NfcFocusHandler.matches(uri)) {
+            toast(getString(R.string.nfc_tag_unrecognized))
+            finish()
+            return
+        }
+
+        val appContext = applicationContext
+        CoroutineScope(Dispatchers.IO).launch {
+            val result = NfcFocusHandler.handle(appContext, uri)
+            withContext(Dispatchers.Main) {
+                if (result is NfcFocusHandler.Result.Started || result is NfcFocusHandler.Result.Stopped) {
+                    NfcUnlockUtils.feedback(this@NfcTriggerActivity)
+                }
+                messageFor(result)?.let { toast(it) }
+                finish()
+            }
+        }
+    }
+
+    /** Pulls the URI from either a plain view intent or an NDEF-discovered NFC intent. */
+    private fun extractUri(intent: Intent?): Uri? {
+        if (intent == null) return null
+        intent.data?.let { return it }
+
+        val rawMessages = intent.getParcelableArrayExtra(NfcAdapter.EXTRA_NDEF_MESSAGES) ?: return null
+        for (raw in rawMessages) {
+            val message = raw as? NdefMessage ?: continue
+            for (record in message.records) {
+                uriFromRecord(record)?.let { return it }
+            }
+        }
+        return null
+    }
+
+    private fun uriFromRecord(record: NdefRecord): Uri? = try {
+        record.toUri() ?: run {
+            if (record.tnf == NdefRecord.TNF_ABSOLUTE_URI) {
+                Uri.parse(String(record.type, Charsets.UTF_8))
+            } else null
+        }
+    } catch (e: Exception) {
+        null
+    }
+
+    private fun messageFor(result: NfcFocusHandler.Result): String? = when (result) {
+        is NfcFocusHandler.Result.Started ->
+            getString(R.string.nfc_focus_started, result.groupName, result.minutes)
+        NfcFocusHandler.Result.Stopped -> getString(R.string.nfc_focus_stopped)
+        NfcFocusHandler.Result.NoGroup -> getString(R.string.nfc_focus_no_group)
+        NfcFocusHandler.Result.NotExitable -> getString(R.string.nfc_focus_not_exitable)
+        NfcFocusHandler.Result.Invalid -> getString(R.string.nfc_tag_unrecognized)
+        NfcFocusHandler.Result.Debounced -> null
+    }
+
+    private fun toast(text: String) {
+        Toast.makeText(this, text, Toast.LENGTH_SHORT).show()
+    }
+}

--- a/app/src/main/java/neth/iecal/curbox/nfc/NfcUnlockUtils.kt
+++ b/app/src/main/java/neth/iecal/curbox/nfc/NfcUnlockUtils.kt
@@ -1,0 +1,168 @@
+package neth.iecal.curbox.nfc
+
+import android.app.Activity
+import android.os.Build
+import android.os.Handler
+import android.os.Looper
+import android.nfc.NdefMessage
+import android.nfc.NdefRecord
+import android.nfc.NfcAdapter
+import android.nfc.Tag
+import android.nfc.tech.Ndef
+import android.nfc.tech.NdefFormatable
+
+/**
+ * Shared NFC helpers for the unlock-method feature.
+ *
+ * A tag matches by the text payload Curbox wrote onto it ("write new tag") or by its hardware UID
+ * ("register existing tag"). [keysFromTag] returns both candidates, so either registration style
+ * unlocks if it hits the stored key map.
+ */
+object NfcUnlockUtils {
+
+    /** Reader-mode flags covering the common tag technologies. */
+    const val READER_FLAGS =
+        NfcAdapter.FLAG_READER_NFC_A or
+            NfcAdapter.FLAG_READER_NFC_B or
+            NfcAdapter.FLAG_READER_NFC_F or
+            NfcAdapter.FLAG_READER_NFC_V or
+            NfcAdapter.FLAG_READER_NO_PLATFORM_SOUNDS
+
+    fun isNfcReady(activity: Activity): Boolean {
+        val adapter = NfcAdapter.getDefaultAdapter(activity) ?: return false
+        return adapter.isEnabled
+    }
+
+    fun enableReader(activity: Activity, onTag: (Tag) -> Unit): Boolean {
+        if (activity.isFinishing || activity.isDestroyed) return false
+        val adapter = NfcAdapter.getDefaultAdapter(activity) ?: return false
+        val mainHandler = Handler(Looper.getMainLooper())
+        return try {
+            adapter.enableReaderMode(activity, { tag ->
+                mainHandler.post { onTag(tag) }
+            }, READER_FLAGS, null)
+            true
+        } catch (e: IllegalStateException) {
+            false
+        }
+    }
+
+    fun disableReader(activity: Activity) {
+        if (activity.isFinishing || activity.isDestroyed) return
+        try {
+            NfcAdapter.getDefaultAdapter(activity)?.disableReaderMode(activity)
+        } catch (e: IllegalStateException) {
+            // Activity already torn down (e.g. rapid destroy); nothing to disable.
+        }
+    }
+
+    fun feedback(context: android.content.Context) {
+        try {
+            val vibrator = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+                (context.getSystemService(android.content.Context.VIBRATOR_MANAGER_SERVICE)
+                    as android.os.VibratorManager).defaultVibrator
+            } else {
+                @Suppress("DEPRECATION")
+                context.getSystemService(android.content.Context.VIBRATOR_SERVICE) as android.os.Vibrator
+            }
+            if (!vibrator.hasVibrator()) return
+            vibrator.vibrate(
+                android.os.VibrationEffect.createOneShot(60, android.os.VibrationEffect.DEFAULT_AMPLITUDE)
+            )
+        } catch (e: Exception) {
+            // Feedback is best-effort.
+        }
+    }
+
+    fun uidHex(tag: Tag): String =
+        tag.id?.joinToString("") { "%02X".format(it) } ?: ""
+
+    /**
+     * Every string a scanned [tag] could be registered under: its UID plus any text/URI NDEF
+     * payloads already on it.
+     */
+    fun keysFromTag(tag: Tag): List<String> {
+        val keys = mutableListOf<String>()
+        uidHex(tag).takeIf { it.isNotEmpty() }?.let { keys.add(it) }
+
+        try {
+            val ndef = Ndef.get(tag)
+            if (ndef != null) {
+                ndef.connect()
+                val message = ndef.ndefMessage ?: ndef.cachedNdefMessage
+                message?.records?.forEach { record ->
+                    payloadOf(record)?.let { keys.add(it) }
+                }
+                ndef.close()
+            }
+        } catch (e: Exception) {
+            // Unreadable / non-NDEF tag: UID alone still works.
+        }
+        return keys
+    }
+
+    fun writeText(tag: Tag, text: String): Boolean =
+        writeMessage(tag, NdefMessage(arrayOf(NdefRecord.createTextRecord(null, text))))
+
+    fun writeUri(tag: Tag, uri: String): Boolean =
+        writeMessage(tag, NdefMessage(arrayOf(NdefRecord.createUri(uri))))
+
+    fun readUri(tag: Tag): android.net.Uri? = try {
+        val ndef = Ndef.get(tag)
+        var result: android.net.Uri? = null
+        if (ndef != null) {
+            ndef.connect()
+            val message = ndef.ndefMessage ?: ndef.cachedNdefMessage
+            result = message?.records?.firstNotNullOfOrNull { it.toUri() }
+            ndef.close()
+        }
+        result
+    } catch (e: Exception) {
+        null
+    }
+
+    private fun writeMessage(tag: Tag, message: NdefMessage): Boolean {
+        return try {
+            val ndef = Ndef.get(tag)
+            if (ndef != null) {
+                ndef.connect()
+                if (!ndef.isWritable || ndef.maxSize < message.toByteArray().size) {
+                    ndef.close()
+                    return false
+                }
+                ndef.writeNdefMessage(message)
+                ndef.close()
+                true
+            } else {
+                val formatable = NdefFormatable.get(tag) ?: return false
+                formatable.connect()
+                formatable.format(message)
+                formatable.close()
+                true
+            }
+        } catch (e: Exception) {
+            false
+        }
+    }
+
+    private fun payloadOf(record: NdefRecord): String? = try {
+        when {
+            record.toUri() != null -> record.toUri().toString()
+            record.tnf == NdefRecord.TNF_WELL_KNOWN &&
+                record.type.contentEquals(NdefRecord.RTD_TEXT) -> decodeText(record)
+            else -> null
+        }
+    } catch (e: Exception) {
+        null
+    }
+
+    /** Decodes an RTD_TEXT record payload into its text, stripping the language header. */
+    private fun decodeText(record: NdefRecord): String? {
+        val payload = record.payload
+        if (payload.isEmpty()) return null
+        val langLength = payload[0].toInt() and 0x3F
+        val isUtf16 = (payload[0].toInt() and 0x80) != 0
+        val charset = if (isUtf16) Charsets.UTF_16 else Charsets.UTF_8
+        return String(payload, 1 + langLength, payload.size - 1 - langLength, charset)
+    }
+}

--- a/app/src/main/java/neth/iecal/curbox/ui/activity/WarningActivity.kt
+++ b/app/src/main/java/neth/iecal/curbox/ui/activity/WarningActivity.kt
@@ -341,12 +341,13 @@ class WarningActivity : AppCompatActivity() {
             if (mode == Constants.WARNING_SCREEN_MODE_APP_BLOCKER) {
                 intent.getStringExtra("result_id")
                     ?.let { it1 ->
-                        val finalTime = if (warningScreenConfig.isOnOpenConfig) {
-                            1440
-                        } else if ((warningScreenConfig.isQrUnlockRequirementEnabled || warningScreenConfig.isNfcUnlockRequirementEnabled) && scannedValidDuration != -1L) {
-                            (scannedValidDuration / 60000).toInt()
-                        } else {
-                            binding.minsPicker.getValue()
+                        val hasUnlockChallenge = warningScreenConfig.isQrUnlockRequirementEnabled ||
+                            warningScreenConfig.isNfcUnlockRequirementEnabled
+                        val finalTime = when {
+                            hasUnlockChallenge && scannedValidDuration != -1L -> (scannedValidDuration / 60000).toInt()
+                            hasUnlockChallenge -> binding.minsPicker.getValue()
+                            warningScreenConfig.isOnOpenConfig -> 1440
+                            else -> binding.minsPicker.getValue()
                         }
                         sendRefreshRequest(
                             it1,

--- a/app/src/main/java/neth/iecal/curbox/ui/activity/WarningActivity.kt
+++ b/app/src/main/java/neth/iecal/curbox/ui/activity/WarningActivity.kt
@@ -19,6 +19,7 @@ import com.google.gson.Gson
 import com.journeyapps.barcodescanner.ScanContract
 import com.journeyapps.barcodescanner.ScanOptions
 import neth.iecal.curbox.Constants
+import neth.iecal.curbox.nfc.NfcUnlockUtils
 import neth.iecal.curbox.R
 import neth.iecal.curbox.blockers.AppBlocker
 import neth.iecal.curbox.blockers.KeywordBlocker
@@ -43,6 +44,9 @@ class WarningActivity : AppCompatActivity() {
     private var vibrator: Vibrator? = null
 
     private var isQrScanned = false
+    private var isNfcScanned = false
+    private var nfcReaderActive = false
+    private var nfcTapDialog: AlertDialog? = null
     private var scannedValidDuration = -1L
 
     private lateinit var binding: DialogWarningOverlayBinding
@@ -147,7 +151,7 @@ class WarningActivity : AppCompatActivity() {
 
                     override fun onFinish() {
                         binding.btnProceed.let { button ->
-                            if (!warningScreenConfig.isQrUnlockRequirementEnabled && warningScreenConfig.isDynamicIntervalSettingAllowed) {
+                            if (!warningScreenConfig.isQrUnlockRequirementEnabled && !warningScreenConfig.isNfcUnlockRequirementEnabled && warningScreenConfig.isDynamicIntervalSettingAllowed) {
                                 binding.minsPicker.visibility = View.VISIBLE
                             }
 
@@ -219,6 +223,9 @@ class WarningActivity : AppCompatActivity() {
                             } else if (warningScreenConfig.isQrUnlockRequirementEnabled && !isQrScanned) {
                                 button.text = getString(R.string.warning_scan_qr_code)
                                 button.isEnabled = true
+                            } else if (warningScreenConfig.isNfcUnlockRequirementEnabled && !isNfcScanned) {
+                                button.text = getString(R.string.warning_scan_nfc_tag)
+                                button.isEnabled = true
                             } else {
                                 button.setText(R.string.proceed)
                                 button.isEnabled = true
@@ -269,6 +276,11 @@ class WarningActivity : AppCompatActivity() {
                 return@setOnClickListener
             }
 
+            if (warningScreenConfig.isNfcUnlockRequirementEnabled && !isNfcScanned) {
+                startNfcUnlockScan(warningScreenConfig)
+                return@setOnClickListener
+            }
+
             if (warningScreenConfig.proceedLimitEnabled && targetId.isNotEmpty()) {
                 val limitPrefs = getSharedPreferences("proceed_limits", Context.MODE_PRIVATE)
                 val historyString = limitPrefs.getString("proceeds_$targetId", "") ?: ""
@@ -313,7 +325,7 @@ class WarningActivity : AppCompatActivity() {
             if (mode == Constants.WARNING_SCREEN_MODE_VIEW_BLOCKER) {
                 intent.getStringExtra("result_id")
                     ?.let { it1 ->
-                        val finalTime = if (warningScreenConfig.isQrUnlockRequirementEnabled && scannedValidDuration != -1L) {
+                        val finalTime = if ((warningScreenConfig.isQrUnlockRequirementEnabled || warningScreenConfig.isNfcUnlockRequirementEnabled) && scannedValidDuration != -1L) {
                             (scannedValidDuration / 60000).toInt()
                         } else {
                             binding.minsPicker.getValue()
@@ -331,7 +343,7 @@ class WarningActivity : AppCompatActivity() {
                     ?.let { it1 ->
                         val finalTime = if (warningScreenConfig.isOnOpenConfig) {
                             1440
-                        } else if (warningScreenConfig.isQrUnlockRequirementEnabled && scannedValidDuration != -1L) {
+                        } else if ((warningScreenConfig.isQrUnlockRequirementEnabled || warningScreenConfig.isNfcUnlockRequirementEnabled) && scannedValidDuration != -1L) {
                             (scannedValidDuration / 60000).toInt()
                         } else {
                             binding.minsPicker.getValue()
@@ -352,7 +364,7 @@ class WarningActivity : AppCompatActivity() {
             if (mode == Constants.WARNING_SCREEN_MODE_KEYWORD_BLOCKER) {
                 intent.getStringExtra("result_id")
                     ?.let { it1 ->
-                        val finalTime = if (warningScreenConfig.isQrUnlockRequirementEnabled && scannedValidDuration != -1L) {
+                        val finalTime = if ((warningScreenConfig.isQrUnlockRequirementEnabled || warningScreenConfig.isNfcUnlockRequirementEnabled) && scannedValidDuration != -1L) {
                             (scannedValidDuration / 60000).toInt()
                         } else {
                             binding.minsPicker.getValue()
@@ -370,8 +382,58 @@ class WarningActivity : AppCompatActivity() {
         }
     }
 
+    private fun startNfcUnlockScan(warningScreenConfig: AppBlockerWarningScreenConfig) {
+        if (!NfcUnlockUtils.isNfcReady(this)) {
+            Toast.makeText(this, R.string.nfc_unavailable, Toast.LENGTH_LONG).show()
+            return
+        }
+
+        val enabled = NfcUnlockUtils.enableReader(this) { tag ->
+            NfcUnlockUtils.feedback(this)
+            val match = NfcUnlockUtils.keysFromTag(tag)
+                .firstOrNull { warningScreenConfig.nfcKeys.containsKey(it) }
+            if (match != null) {
+                isNfcScanned = true
+                scannedValidDuration = warningScreenConfig.nfcKeys[match] ?: -1L
+                binding.btnProceed.isEnabled = true
+                binding.btnProceed.setText(R.string.proceed)
+                binding.minsPicker.visibility = if (scannedValidDuration == -1L) View.VISIBLE else View.GONE
+                stopNfcUnlockScan()
+            } else {
+                Toast.makeText(this, R.string.warning_invalid_nfc, Toast.LENGTH_LONG).show()
+            }
+        }
+        if (!enabled) {
+            Toast.makeText(this, R.string.nfc_unavailable, Toast.LENGTH_LONG).show()
+            return
+        }
+        nfcReaderActive = true
+
+        nfcTapDialog = MaterialAlertDialogBuilder(this)
+            .setTitle(R.string.nfc_tap_title)
+            .setMessage(R.string.nfc_tap_message)
+            .setNegativeButton(R.string.cancel) { _, _ -> stopNfcUnlockScan() }
+            .setOnDismissListener { stopNfcUnlockScan() }
+            .show()
+    }
+
+    private fun stopNfcUnlockScan() {
+        if (nfcReaderActive) {
+            NfcUnlockUtils.disableReader(this)
+            nfcReaderActive = false
+        }
+        nfcTapDialog?.dismiss()
+        nfcTapDialog = null
+    }
+
+    override fun onPause() {
+        super.onPause()
+        stopNfcUnlockScan()
+    }
+
     override fun onDestroy() {
         super.onDestroy()
+        stopNfcUnlockScan()
         proceedTimer?.cancel()
         vibrator?.cancel()
         dialog?.dismiss()

--- a/app/src/main/java/neth/iecal/curbox/ui/fragments/main/focus/FocusFragment.kt
+++ b/app/src/main/java/neth/iecal/curbox/ui/fragments/main/focus/FocusFragment.kt
@@ -16,6 +16,10 @@ import androidx.recyclerview.widget.RecyclerView
 import java.util.Locale
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.launch
+import android.widget.Toast
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
+import neth.iecal.curbox.nfc.NfcFocusHandler
+import neth.iecal.curbox.nfc.NfcUnlockUtils
 import neth.iecal.curbox.utils.ViewUtils
 import neth.iecal.curbox.R
 import neth.iecal.curbox.databinding.FragmentFocusBinding
@@ -32,6 +36,7 @@ class FocusFragment : Fragment() {
     private var isProgrammaticScroll = false
     private var itemWidthPx = 0
     private val snapHelper = LinearSnapHelper()
+    private var nfcTapDialog: androidx.appcompat.app.AlertDialog? = null
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -161,6 +166,181 @@ class FocusFragment : Fragment() {
         binding.btnHelp.setOnClickListener {
             ViewUtils.showHelpPopup(it, "Focus mode helps you stay away from distractions for a set period of time.", "https://curbox.app/docs/focus/focus-mode/")
         }
+
+        binding.btnWriteFocusNfc.setOnClickListener {
+            showWriteFocusNfcDialog()
+        }
+    }
+
+    private val focusNfcActions = listOf("toggle", "start", "stop")
+
+    private fun showWriteFocusNfcDialog() {
+        val groups = viewModel.groups.value
+        if (groups.isEmpty()) {
+            Toast.makeText(requireContext(), R.string.focus_nfc_no_groups, Toast.LENGTH_LONG).show()
+            return
+        }
+
+        val ctx = requireContext()
+        val view = layoutInflater.inflate(R.layout.dialog_focus_nfc_write, null)
+        val groupInput = view.findViewById<com.google.android.material.textfield.MaterialAutoCompleteTextView>(R.id.group_input)
+        val actionInput = view.findViewById<com.google.android.material.textfield.MaterialAutoCompleteTextView>(R.id.action_input)
+        val durationLayout = view.findViewById<com.google.android.material.textfield.TextInputLayout>(R.id.duration_layout)
+        val durationInput = view.findViewById<com.google.android.material.textfield.TextInputEditText>(R.id.duration_input)
+
+        val groupNames = groups.map { it.groupName.ifBlank { getString(R.string.focus_nfc_unnamed_group) } }
+        val actionNames = listOf(
+            getString(R.string.focus_nfc_action_toggle),
+            getString(R.string.focus_nfc_action_start),
+            getString(R.string.focus_nfc_action_stop)
+        )
+        groupInput.setSimpleItems(groupNames.toTypedArray())
+        actionInput.setSimpleItems(actionNames.toTypedArray())
+
+        var groupIdx = 0
+        var actionIdx = 0
+        groupInput.setText(groupNames[0], false)
+        actionInput.setText(actionNames[0], false)
+        durationInput.setText(viewModel.selectedMins.coerceAtLeast(1).toString())
+
+        fun refreshDurationVisibility() {
+            durationLayout.visibility = if (focusNfcActions[actionIdx] == "stop") View.GONE else View.VISIBLE
+        }
+        refreshDurationVisibility()
+
+        groupInput.setOnItemClickListener { _, _, position, _ -> groupIdx = position }
+        actionInput.setOnItemClickListener { _, _, position, _ ->
+            actionIdx = position
+            refreshDurationVisibility()
+        }
+
+        fun applyFromUri(uri: android.net.Uri) {
+            val request = NfcFocusHandler.parse(uri.toString()) ?: return
+            focusNfcActions.indexOf(request.action).takeIf { it >= 0 }?.let {
+                actionIdx = it
+                actionInput.setText(actionNames[it], false)
+            }
+            request.groupId?.let { gid ->
+                groups.indexOfFirst { it.groupId == gid }.takeIf { it >= 0 }?.let {
+                    groupIdx = it
+                    groupInput.setText(groupNames[it], false)
+                }
+            }
+            request.minutes?.coerceAtLeast(1)?.let {
+                durationInput.setText(it.toString())
+            }
+            refreshDurationVisibility()
+        }
+
+        val dialog = MaterialAlertDialogBuilder(ctx)
+            .setTitle(R.string.focus_nfc_write_title)
+            .setView(view)
+            .setPositiveButton(R.string.focus_nfc_write_button, null)
+            .setNegativeButton(R.string.cancel, null)
+            .setNeutralButton(R.string.focus_nfc_load_button, null)
+            .create()
+
+        // Freeze background resizing when the keyboard pops up, so the navbar doesn't jump around
+        val hostWindow = activity?.window
+        val prevSoftInput = hostWindow?.attributes?.softInputMode
+        hostWindow?.setSoftInputMode(android.view.WindowManager.LayoutParams.SOFT_INPUT_ADJUST_NOTHING)
+        dialog.setOnDismissListener {
+            prevSoftInput?.let { hostWindow.setSoftInputMode(it) }
+        }
+
+        dialog.setOnShowListener {
+            dialog.getButton(android.app.AlertDialog.BUTTON_NEUTRAL).setOnClickListener {
+                startFocusNfcLoad { uri -> applyFromUri(uri) }
+            }
+            dialog.getButton(android.app.AlertDialog.BUTTON_POSITIVE).setOnClickListener {
+                if (activity?.let { NfcUnlockUtils.isNfcReady(it) } != true) {
+                    Toast.makeText(requireContext(), R.string.nfc_unavailable, Toast.LENGTH_LONG).show()
+                    return@setOnClickListener
+                }
+                val group = groups[groupIdx]
+                val action = focusNfcActions[actionIdx]
+                val mins = durationInput.text?.toString()?.toIntOrNull()?.coerceAtLeast(1)
+                    ?: viewModel.selectedMins.coerceAtLeast(1)
+                val uri = buildString {
+                    append("curbox://focus/").append(action)
+                    append("?group=").append(android.net.Uri.encode(group.groupId))
+                    if (action != "stop") append("&mins=").append(mins)
+                }
+                dialog.dismiss()
+                startFocusNfcWrite(uri)
+            }
+        }
+        dialog.show()
+    }
+
+    /** The dedicated "tap your tag now" popup, shared by the write and load flows. */
+    private fun showNfcTapDialog(titleRes: Int): androidx.appcompat.app.AlertDialog {
+        val view = layoutInflater.inflate(R.layout.dialog_nfc_tap, null)
+        view.findViewById<android.widget.TextView>(R.id.nfc_tap_title).setText(titleRes)
+        return MaterialAlertDialogBuilder(requireContext())
+            .setView(view)
+            .setNegativeButton(R.string.cancel, null)
+            .setOnDismissListener { stopFocusNfcWrite() }
+            .show()
+    }
+
+    /** Enables reader mode, reads a curbox://focus URI from the tapped tag, and hands it to [onLoaded]. */
+    private fun startFocusNfcLoad(onLoaded: (android.net.Uri) -> Unit) {
+        val activity = activity ?: return
+        if (!NfcUnlockUtils.isNfcReady(activity)) {
+            Toast.makeText(requireContext(), R.string.nfc_unavailable, Toast.LENGTH_LONG).show()
+            return
+        }
+
+        val enabled = NfcUnlockUtils.enableReader(activity) { tag ->
+            NfcUnlockUtils.feedback(requireContext())
+            val uri = NfcUnlockUtils.readUri(tag)
+            if (uri != null && uri.scheme == "curbox" && uri.host == "focus") {
+                onLoaded(uri)
+                Toast.makeText(requireContext(), R.string.focus_nfc_loaded, Toast.LENGTH_SHORT).show()
+            } else {
+                Toast.makeText(requireContext(), R.string.focus_nfc_load_invalid, Toast.LENGTH_LONG).show()
+            }
+            stopFocusNfcWrite()
+        }
+        if (!enabled) {
+            Toast.makeText(requireContext(), R.string.nfc_unavailable, Toast.LENGTH_LONG).show()
+            return
+        }
+
+        nfcTapDialog = showNfcTapDialog(R.string.focus_nfc_load_title)
+    }
+
+    private fun startFocusNfcWrite(uri: String) {
+        val activity = activity ?: return
+        if (!NfcUnlockUtils.isNfcReady(activity)) {
+            Toast.makeText(requireContext(), R.string.nfc_unavailable, Toast.LENGTH_LONG).show()
+            return
+        }
+
+        val enabled = NfcUnlockUtils.enableReader(activity) { tag ->
+            NfcUnlockUtils.feedback(requireContext())
+            val ok = NfcUnlockUtils.writeUri(tag, uri)
+            if (ok) NfcFocusHandler.markTagWritten(requireContext())
+            Toast.makeText(
+                requireContext(),
+                if (ok) R.string.nfc_write_success else R.string.nfc_write_failed,
+                Toast.LENGTH_LONG
+            ).show()
+            stopFocusNfcWrite()
+        }
+        if (!enabled) {
+            Toast.makeText(requireContext(), R.string.nfc_unavailable, Toast.LENGTH_LONG).show()
+            return
+        }
+
+        nfcTapDialog = showNfcTapDialog(R.string.nfc_tap_title)
+    }
+
+    private fun stopFocusNfcWrite() {
+        activity?.let { NfcUnlockUtils.disableReader(it) }
+        nfcTapDialog?.dismiss()
+        nfcTapDialog = null
     }
 
 
@@ -232,8 +412,14 @@ class FocusFragment : Fragment() {
         if (!smooth) updateTime(minutes)
     }
 
+    override fun onPause() {
+        super.onPause()
+        stopFocusNfcWrite()
+    }
+
     override fun onDestroyView() {
         super.onDestroyView()
+        stopFocusNfcWrite()
         _binding = null
     }
 }

--- a/app/src/main/java/neth/iecal/curbox/ui/fragments/main/reducers/blockertools/shared/WarningConfigFragment.kt
+++ b/app/src/main/java/neth/iecal/curbox/ui/fragments/main/reducers/blockertools/shared/WarningConfigFragment.kt
@@ -23,6 +23,7 @@ import com.google.gson.Gson
 import neth.iecal.curbox.R
 import neth.iecal.curbox.data.models.AppBlockerWarningScreenConfig
 import neth.iecal.curbox.data.models.AppBlockingType
+import neth.iecal.curbox.nfc.NfcUnlockUtils
 import neth.iecal.curbox.databinding.FragmentWarningConfigBinding
 import java.util.UUID
 
@@ -34,6 +35,8 @@ class WarningConfigFragment : Fragment() {
     private var initialConfig: AppBlockerWarningScreenConfig? = null
     private var currentQrMap = mutableMapOf<String, Long>()
     private var pendingQrDuration = -1L
+    private var currentNfcMap = mutableMapOf<String, Long>()
+    private var nfcTapDialog: androidx.appcompat.app.AlertDialog? = null
 
     data class UnlockOption(
         val title: String,
@@ -52,7 +55,8 @@ class WarningConfigFragment : Fragment() {
     private val effortOptions = listOf(
         UnlockOption("Unlock requires QR/Barcode scanning", "Scan any code (like a product box) to unlock.", true),
         UnlockOption("Unlock requires typing a sentence", "Precisely type a long sentence to prove focus."),
-        UnlockOption("Unlock requires stating an intent", "Briefly describe your goal before accessing.")
+        UnlockOption("Unlock requires stating an intent", "Briefly describe your goal before accessing."),
+        UnlockOption("Unlock requires scanning an NFC tag", "Tap a physical NFC tag to unlock.")
     )
 
     private val noEffortOptions = listOf(
@@ -126,6 +130,8 @@ class WarningConfigFragment : Fragment() {
         
         currentQrMap = config.qrKeys.toMutableMap()
         updateQrList()
+        currentNfcMap = config.nfcKeys.toMutableMap()
+        updateNfcList()
 
         val challengeAdapter = UnlockOptionAdapter(requireContext(), challengeOptions)
         binding.unlockChallengeDropdown.setAdapter(challengeAdapter)
@@ -136,6 +142,7 @@ class WarningConfigFragment : Fragment() {
                 config.isQrUnlockRequirementEnabled -> 1 to 0
                 config.isTypingRequirementEnabled -> 1 to 1
                 config.isIntentRequirementEnabled -> 1 to 2
+                config.isNfcUnlockRequirementEnabled -> 1 to 3
                 config.isDynamicIntervalSettingAllowed -> 2 to 0
                 else -> 2 to 1 // Fixed time
             }
@@ -157,6 +164,7 @@ class WarningConfigFragment : Fragment() {
             binding.timingContainer.isVisible = false
             binding.proceedDelayContainer.isVisible = false
             binding.qrSetupContainer.isVisible = false
+            binding.nfcSetupContainer.isVisible = false
             binding.typingSetupContainer.isVisible = false
         }
         
@@ -355,7 +363,15 @@ class WarningConfigFragment : Fragment() {
                 barcodeLauncher.launch(options)
             }
         }
-        
+
+        binding.btnWriteNfc.setOnClickListener {
+            showQrConfigDialog { duration -> startNfcTap(write = true, duration = duration) }
+        }
+
+        binding.btnRegisterExistingNfc.setOnClickListener {
+            showQrConfigDialog { duration -> startNfcTap(write = false, duration = duration) }
+        }
+
         binding.saveconfigs.setOnClickListener {
             val challengeStr = binding.unlockChallengeDropdown.text.toString()
             val secondaryStr = binding.secondaryBehaviorDropdown.text.toString()
@@ -366,6 +382,7 @@ class WarningConfigFragment : Fragment() {
             var isQrUnlockRequirementEnabled = false
             var isTypingRequirementEnabled = false
             var isIntentRequirementEnabled = false
+            var isNfcUnlockRequirementEnabled = false
             var isDynamicIntervalSettingAllowed = false
 
             when (cIdx) {
@@ -376,6 +393,7 @@ class WarningConfigFragment : Fragment() {
                         0 -> isQrUnlockRequirementEnabled = true
                         1 -> isTypingRequirementEnabled = true
                         2 -> isIntentRequirementEnabled = true
+                        3 -> isNfcUnlockRequirementEnabled = true
                     }
                 }
                 2 -> {
@@ -392,6 +410,8 @@ class WarningConfigFragment : Fragment() {
                 isWarningDialogHidden = false,
                 isQrUnlockRequirementEnabled = isQrUnlockRequirementEnabled,
                 qrKeys = if (isQrUnlockRequirementEnabled) currentQrMap else mapOf(),
+                isNfcUnlockRequirementEnabled = isNfcUnlockRequirementEnabled,
+                nfcKeys = if (isNfcUnlockRequirementEnabled) currentNfcMap else mapOf(),
                 isTypingRequirementEnabled = isTypingRequirementEnabled,
                 typingSentence = binding.typingSentenceEdit.text.toString(),
                 isIntentRequirementEnabled = isIntentRequirementEnabled,
@@ -468,15 +488,17 @@ class WarningConfigFragment : Fragment() {
         val isOnOpen = arguments?.getBoolean(ARG_IS_ON_OPEN) == true
 
         binding.apply {
-            // Timing container visible if "Requires no effort" + "Fixed time" OR "Require effort" + (Typing or Intent)
-            timingContainer.visibility = if (!isOnOpen && ((challengeIndex == 2 && secondaryIndex == 1) || (challengeIndex == 1 && secondaryIndex != 0 && secondaryIndex != -1))) View.VISIBLE else View.GONE
-            
+            // Timing container visible if "Requires no effort" + "Fixed time" OR "Require effort" + (Typing or Intent).
+            // QR (0) and NFC (3) carry their own per-key timing, so the shared timing slider stays hidden for them.
+            timingContainer.visibility = if (!isOnOpen && ((challengeIndex == 2 && secondaryIndex == 1) || (challengeIndex == 1 && secondaryIndex != 0 && secondaryIndex != 3 && secondaryIndex != -1))) View.VISIBLE else View.GONE
+
             // Proceed delay visible for anything except "Never Unlock" or when nothing selected
             proceedDelayContainer.visibility = if (challengeIndex != 0 && challengeIndex != -1) View.VISIBLE else View.GONE
-            
+
             qrSetupContainer.visibility = if (challengeIndex == 1 && secondaryIndex == 0) View.VISIBLE else View.GONE
             typingSetupContainer.visibility = if (challengeIndex == 1 && secondaryIndex == 1) View.VISIBLE else View.GONE
             intentSetupContainer.visibility = if (challengeIndex == 1 && secondaryIndex == 2) View.VISIBLE else View.GONE
+            nfcSetupContainer.visibility = if (challengeIndex == 1 && secondaryIndex == 3) View.VISIBLE else View.GONE
         }
     }
     
@@ -550,40 +572,103 @@ class WarningConfigFragment : Fragment() {
     }
 
     private fun updateQrList() {
-        binding.qrListContainer.removeAllViews()
-        if (!currentQrMap.isEmpty()) {
-            currentQrMap.forEach { (uuid, duration) ->
-                val itemView = LinearLayout(requireContext()).apply {
-                    orientation = LinearLayout.HORIZONTAL
-                    layoutParams = LinearLayout.LayoutParams(
-                        LinearLayout.LayoutParams.MATCH_PARENT,
-                        LinearLayout.LayoutParams.WRAP_CONTENT
-                    )
-                    setPadding(0, 16, 0, 16)
-                    weightSum = 1f
-                }
-                
-                val infoText = TextView(requireContext()).apply {
-                    val durationText = if (duration == -1L) "Dynamic time" else "${duration / 60000} mins"
-                    text = "QR/Barcode - $durationText"
-                    layoutParams = LinearLayout.LayoutParams(0, LinearLayout.LayoutParams.WRAP_CONTENT, 1f)
-                    setPadding(4, 4, 4, 4)
-                }
-                
-                val removeBtn = com.google.android.material.button.MaterialButton(requireContext(), null, com.google.android.material.R.attr.materialButtonOutlinedStyle).apply {
-                    text = "Remove"
-                    layoutParams = LinearLayout.LayoutParams(LinearLayout.LayoutParams.WRAP_CONTENT, LinearLayout.LayoutParams.WRAP_CONTENT)
-                    setOnClickListener {
-                        currentQrMap.remove(uuid)
-                        updateQrList()
-                    }
-                }
-                
-                itemView.addView(infoText)
-                itemView.addView(removeBtn)
-                binding.qrListContainer.addView(itemView)
+        renderKeyList(binding.qrListContainer, currentQrMap, "QR/Barcode") { updateQrList() }
+    }
+
+    private fun renderKeyList(
+        container: LinearLayout,
+        map: MutableMap<String, Long>,
+        label: String,
+        refresh: () -> Unit
+    ) {
+        container.removeAllViews()
+        map.forEach { (key, duration) ->
+            val itemView = LinearLayout(requireContext()).apply {
+                orientation = LinearLayout.HORIZONTAL
+                layoutParams = LinearLayout.LayoutParams(
+                    LinearLayout.LayoutParams.MATCH_PARENT,
+                    LinearLayout.LayoutParams.WRAP_CONTENT
+                )
+                setPadding(0, 16, 0, 16)
+                weightSum = 1f
             }
+
+            val infoText = TextView(requireContext()).apply {
+                val durationText = if (duration == -1L) "Dynamic time" else "${duration / 60000} mins"
+                text = "$label - $durationText"
+                layoutParams = LinearLayout.LayoutParams(0, LinearLayout.LayoutParams.WRAP_CONTENT, 1f)
+                setPadding(4, 4, 4, 4)
+            }
+
+            val removeBtn = com.google.android.material.button.MaterialButton(requireContext(), null, com.google.android.material.R.attr.materialButtonOutlinedStyle).apply {
+                text = "Remove"
+                layoutParams = LinearLayout.LayoutParams(LinearLayout.LayoutParams.WRAP_CONTENT, LinearLayout.LayoutParams.WRAP_CONTENT)
+                setOnClickListener {
+                    map.remove(key)
+                    refresh()
+                }
+            }
+
+            itemView.addView(infoText)
+            itemView.addView(removeBtn)
+            container.addView(itemView)
         }
+    }
+
+    private fun startNfcTap(write: Boolean, duration: Long) {
+        val activity = activity ?: return
+        if (!NfcUnlockUtils.isNfcReady(activity)) {
+            Toast.makeText(requireContext(), R.string.nfc_unavailable, Toast.LENGTH_LONG).show()
+            return
+        }
+
+        val enabled = NfcUnlockUtils.enableReader(activity) { tag ->
+            NfcUnlockUtils.feedback(requireContext())
+            if (write) {
+                val uuid = UUID.randomUUID().toString()
+                if (NfcUnlockUtils.writeText(tag, uuid)) {
+                    currentNfcMap[uuid] = duration
+                    updateNfcList()
+                    Toast.makeText(requireContext(), R.string.nfc_write_success, Toast.LENGTH_SHORT).show()
+                } else {
+                    Toast.makeText(requireContext(), R.string.nfc_write_failed, Toast.LENGTH_LONG).show()
+                }
+            } else {
+                val key = NfcUnlockUtils.keysFromTag(tag).firstOrNull()
+                if (key == null) {
+                    Toast.makeText(requireContext(), R.string.nfc_write_failed, Toast.LENGTH_LONG).show()
+                } else if (currentNfcMap.containsKey(key)) {
+                    Toast.makeText(requireContext(), R.string.nfc_already_registered, Toast.LENGTH_SHORT).show()
+                } else {
+                    currentNfcMap[key] = duration
+                    updateNfcList()
+                    Toast.makeText(requireContext(), R.string.nfc_tag_saved, Toast.LENGTH_SHORT).show()
+                }
+            }
+            stopNfcTap()
+        }
+
+        if (!enabled) {
+            Toast.makeText(requireContext(), R.string.nfc_unavailable, Toast.LENGTH_LONG).show()
+            return
+        }
+
+        nfcTapDialog = MaterialAlertDialogBuilder(requireContext())
+            .setTitle(R.string.nfc_tap_title)
+            .setMessage(R.string.nfc_tap_message)
+            .setNegativeButton(R.string.cancel) { _, _ -> stopNfcTap() }
+            .setOnDismissListener { activity.let { NfcUnlockUtils.disableReader(it) } }
+            .show()
+    }
+
+    private fun stopNfcTap() {
+        activity?.let { NfcUnlockUtils.disableReader(it) }
+        nfcTapDialog?.dismiss()
+        nfcTapDialog = null
+    }
+
+    private fun updateNfcList() {
+        renderKeyList(binding.nfcListContainer, currentNfcMap, "NFC tag") { updateNfcList() }
     }
 
     private fun updateProceedWindowSliderBounds(unitIdx: Int) {
@@ -611,8 +696,14 @@ class WarningConfigFragment : Fragment() {
         binding.proceedWindowTitle.text = getString(R.string.warning_time_window, value, unitOptions[unitIdx])
     }
 
+    override fun onPause() {
+        super.onPause()
+        stopNfcTap()
+    }
+
     override fun onDestroyView() {
         super.onDestroyView()
+        stopNfcTap()
         _binding = null
     }
 

--- a/app/src/main/java/neth/iecal/curbox/utils/RestrictionComparator.kt
+++ b/app/src/main/java/neth/iecal/curbox/utils/RestrictionComparator.kt
@@ -253,18 +253,10 @@ object RestrictionComparator {
                 n.allowedProceeds <= o.allowedProceeds && n.proceedsTimeWindowMn >= o.proceedsTimeWindowMn
             else -> true
         }
-        val qrOk = when {
-            o.isQrUnlockRequirementEnabled && !n.isQrUnlockRequirementEnabled -> false
-            // A new QR key is a new way to unlock, so keys may only be kept or removed,
-            // and a kept key may not unlock for longer than before
-            o.isQrUnlockRequirementEnabled && n.isQrUnlockRequirementEnabled ->
-                n.qrKeys.all { (key, duration) ->
-                    val oldDuration = o.qrKeys[key] ?: return@all false
-                    if (oldDuration == -1L || duration == -1L) duration == oldDuration
-                    else duration <= oldDuration
-                }
-            else -> true
-        }
+        // QR and NFC share the same rule: a key/tag is a new way to unlock, so keys may only be
+        // kept or removed, and a kept key may not unlock for longer than before.
+        val qrOk = unlockKeysOk(o.isQrUnlockRequirementEnabled, n.isQrUnlockRequirementEnabled, o.qrKeys, n.qrKeys)
+        val nfcOk = unlockKeysOk(o.isNfcUnlockRequirementEnabled, n.isNfcUnlockRequirementEnabled, o.nfcKeys, n.nfcKeys)
         val typingOk = !o.isTypingRequirementEnabled || n.isTypingRequirementEnabled
         val intentOk = !o.isIntentRequirementEnabled || n.isIntentRequirementEnabled
         val intentMinLengthOk = when {
@@ -273,8 +265,28 @@ object RestrictionComparator {
         }
 
         return cooldownOk && dynamicIntervalOk && proceedDisabledOk && dialogHiddenOk &&
-            proceedDelayOk && vibrateOk && proceedLimitOk && qrOk && typingOk && intentOk &&
+            proceedDelayOk && vibrateOk && proceedLimitOk && qrOk && nfcOk && typingOk && intentOk &&
             intentMinLengthOk
+    }
+
+    /**
+     * Shared "unlock keys may only get stricter" rule for QR and NFC. Disabling the requirement or
+     * adding a new key/tag weakens the block; a kept key may not unlock for longer than before, and
+     * dynamic timing (-1) is only same-or-stricter when it is unchanged.
+     */
+    private fun unlockKeysOk(
+        oldEnabled: Boolean,
+        newEnabled: Boolean,
+        oldKeys: Map<String, Long>,
+        newKeys: Map<String, Long>
+    ): Boolean = when {
+        oldEnabled && !newEnabled -> false
+        oldEnabled && newEnabled -> newKeys.all { (key, duration) ->
+            val oldDuration = oldKeys[key] ?: return@all false
+            if (oldDuration == -1L || duration == -1L) duration == oldDuration
+            else duration <= oldDuration
+        }
+        else -> true
     }
 
     private inline fun <reified T> parse(json: String): T? =

--- a/app/src/main/res/drawable/baseline_nfc_24.xml
+++ b/app/src/main/res/drawable/baseline_nfc_24.xml
@@ -1,0 +1,5 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:height="24dp" android:tint="#000000" android:viewportHeight="24" android:viewportWidth="24" android:width="24dp">
+
+    <path android:fillColor="@android:color/white" android:pathData="M20,2L4,2c-1.1,0 -2,0.9 -2,2v16c0,1.1 0.9,2 2,2h16c1.1,0 2,-0.9 2,-2L22,4c0,-1.1 -0.9,-2 -2,-2zM20,20L4,20L4,4h16v16zM18,6h-5c-1.1,0 -2,0.9 -2,2v2.28c-0.6,0.35 -1,0.98 -1,1.72 0,1.1 0.9,2 2,2s2,-0.9 2,-2c0,-0.74 -0.4,-1.38 -1,-1.72L13,8h3v8L8,16L8,8h1L9,6L6,6v12h12L18,6z"/>
+
+</vector>

--- a/app/src/main/res/layout/dialog_focus_nfc_write.xml
+++ b/app/src/main/res/layout/dialog_focus_nfc_write.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:paddingStart="24dp"
+    android:paddingEnd="24dp"
+    android:paddingTop="8dp">
+
+    <com.google.android.material.textfield.TextInputLayout
+        android:id="@+id/group_layout"
+        style="@style/Widget.Material3.TextInputLayout.OutlinedBox.ExposedDropdownMenu"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
+        android:hint="@string/focus_nfc_pick_group">
+
+        <com.google.android.material.textfield.MaterialAutoCompleteTextView
+            android:id="@+id/group_input"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:inputType="none"
+            android:focusable="false" />
+    </com.google.android.material.textfield.TextInputLayout>
+
+    <com.google.android.material.textfield.TextInputLayout
+        android:id="@+id/action_layout"
+        style="@style/Widget.Material3.TextInputLayout.OutlinedBox.ExposedDropdownMenu"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="16dp"
+        android:hint="@string/focus_nfc_pick_action">
+
+        <com.google.android.material.textfield.MaterialAutoCompleteTextView
+            android:id="@+id/action_input"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:inputType="none"
+            android:focusable="false" />
+    </com.google.android.material.textfield.TextInputLayout>
+
+    <com.google.android.material.textfield.TextInputLayout
+        android:id="@+id/duration_layout"
+        style="@style/Widget.Material3.TextInputLayout.OutlinedBox"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="16dp"
+        app:suffixText="@string/common_mins"
+        android:hint="@string/focus_nfc_duration_input_hint">
+
+        <com.google.android.material.textfield.TextInputEditText
+            android:id="@+id/duration_input"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:inputType="number"
+            android:maxLength="4" />
+    </com.google.android.material.textfield.TextInputLayout>
+
+</LinearLayout>

--- a/app/src/main/res/layout/dialog_nfc_tap.xml
+++ b/app/src/main/res/layout/dialog_nfc_tap.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:gravity="center_horizontal"
+    android:paddingStart="24dp"
+    android:paddingEnd="24dp"
+    android:paddingTop="24dp"
+    android:paddingBottom="8dp">
+
+    <ImageView
+        android:layout_width="72dp"
+        android:layout_height="72dp"
+        android:src="@drawable/baseline_nfc_24"
+        android:contentDescription="@string/nfc_tap_title"
+        app:tint="?attr/colorPrimary"
+        xmlns:app="http://schemas.android.com/apk/res-auto" />
+
+    <TextView
+        android:id="@+id/nfc_tap_title"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="16dp"
+        android:text="@string/nfc_tap_title"
+        android:textAppearance="@style/TextAppearance.Material3.TitleMedium" />
+
+    <TextView
+        android:id="@+id/nfc_tap_message"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
+        android:gravity="center"
+        android:text="@string/nfc_tap_message"
+        android:textAppearance="@style/TextAppearance.Material3.BodyMedium" />
+
+</LinearLayout>

--- a/app/src/main/res/layout/fragment_focus.xml
+++ b/app/src/main/res/layout/fragment_focus.xml
@@ -55,6 +55,16 @@
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintTop_toTopOf="parent" />
 
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/btn_write_focus_nfc"
+            style="@style/Widget.Material3.Button.IconButton"
+            android:layout_width="48dp"
+            android:layout_height="48dp"
+            android:contentDescription="@string/focus_nfc_write_title"
+            app:icon="@drawable/baseline_nfc_24"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/btn_help" />
+
         <ImageButton
             android:id="@+id/btnGoToStats"
             android:layout_width="48dp"

--- a/app/src/main/res/layout/fragment_warning_config.xml
+++ b/app/src/main/res/layout/fragment_warning_config.xml
@@ -194,6 +194,66 @@
         </com.google.android.material.card.MaterialCardView>
 
         <com.google.android.material.card.MaterialCardView
+            android:id="@+id/nfc_setup_container"
+            style="@style/Widget.Material3.CardView.Outlined"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="16dp"
+            android:visibility="gone">
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="vertical"
+                android:padding="16dp">
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/label_nfc_auth"
+                    style="@style/TextAppearance.Material3.TitleMedium" />
+
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="16dp"
+                    android:weightSum="2">
+
+                    <Button
+                        android:id="@+id/btn_write_nfc"
+                        android:layout_width="0dp"
+                        android:layout_weight="1"
+                        android:layout_marginEnd="4dp"
+                        android:layout_height="wrap_content"
+                        android:text="@string/btn_generate_new" />
+
+                    <Button
+                        android:id="@+id/btn_register_existing_nfc"
+                        android:layout_width="0dp"
+                        android:layout_weight="1"
+                        android:layout_marginStart="4dp"
+                        android:layout_height="wrap_content"
+                        style="?attr/materialButtonOutlinedStyle"
+                        android:text="@string/btn_scan_existing" />
+                </LinearLayout>
+
+                <TextView
+                    style="@style/TextAppearance.Material3.TitleSmall"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="16dp"
+                    android:text="@string/label_configured_nfc" />
+
+                <LinearLayout
+                    android:id="@+id/nfc_list_container"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="vertical" />
+
+            </LinearLayout>
+        </com.google.android.material.card.MaterialCardView>
+
+        <com.google.android.material.card.MaterialCardView
             android:id="@+id/typing_setup_container"
             style="@style/Widget.Material3.CardView.Outlined"
             android:layout_width="match_parent"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -330,6 +330,12 @@
     <string name="notification_title_remaining_usage">Remaining usage before lockdown</string>
     <string name="notification_title_focus_mode_on">Focus Mode is on</string>
 
+    <string name="nfc_focus_started">Focus started: %1$s (%2$d min)</string>
+    <string name="nfc_focus_stopped">Focus stopped</string>
+    <string name="nfc_focus_no_group">No focus group found to start</string>
+    <string name="nfc_focus_not_exitable">This focus session can\'t be ended early</string>
+    <string name="nfc_tag_unrecognized">Unrecognized Curbox NFC tag</string>
+
     <string name="onboarding_non_session_title">Non-session based installation detected</string>
     <string name="onboarding_restricted_settings_desc">Android 13+ restricts Accessibility services for apps installed outside of app stores (like F-Droid or Play Store). To enable permissions, you\'ll need to manually allow \'Restricted settings\' for Curbox. Alternatively, install via the F-Droid app(not website) to avoid this.</string>
     <string name="onboarding_show_tutorial">Show tutorial to enable permissions</string>
@@ -396,6 +402,8 @@
     <string name="btn_generate_new">Generate New</string>
     <string name="btn_scan_existing">Scan Existing</string>
     <string name="label_configured_qr">Configured QR/Barcodes:</string>
+    <string name="label_nfc_auth">NFC Authentication</string>
+    <string name="label_configured_nfc">Configured NFC tags:</string>
     <string name="label_typing_auth">Typing Authentication</string>
     <string name="label_typing_desc">Enter the sentence the user must type exactly to bypass the block:</string>
     <string name="label_intent_auth">Intent unlock length</string>
@@ -1471,8 +1479,8 @@
     <string name="warning_saved_to_gallery">Saved to Gallery!</string>
     <string name="warning_save_image_failed">Failed to save image</string>
     <string name="warning_mediastore_failed">Failed to create MediaStore entry</string>
-    <string name="warning_qr_timing_title">QR/Barcode Timing</string>
-    <string name="warning_qr_timing_message">Configure the time behavior for this code before continuing.</string>
+    <string name="warning_qr_timing_title">Unlock Timing</string>
+    <string name="warning_qr_timing_message">Configure the time behavior for this unlock method before continuing.</string>
     <string name="warning_qr_saved">QR Code Saved Successfully!</string>
     <string name="warning_scan_cancelled">Scan cancelled</string>
     <string name="warning_cancelled">Cancelled</string>
@@ -1481,6 +1489,29 @@
     <string name="warning_proceeds_left">You have %1$d of %2$d opens left</string>
     <string name="warning_typing_quote">\"%1$s\"</string>
     <string name="warning_scan_qr_code">Scan QR Code</string>
+    <string name="warning_scan_nfc_tag">Scan NFC Tag</string>
+    <string name="warning_invalid_nfc">This NFC tag is not registered</string>
+    <string name="nfc_tap_title">Tap your NFC tag</string>
+    <string name="nfc_tap_message">Hold your NFC tag against the back of your phone.</string>
+    <string name="nfc_unavailable">NFC is off or unavailable on this device</string>
+    <string name="nfc_tag_saved">NFC tag registered</string>
+    <string name="nfc_write_failed">Could not write to tag. Use a writable NFC tag.</string>
+    <string name="nfc_write_success">Tag written and registered</string>
+    <string name="nfc_already_registered">That tag is already registered</string>
+    <string name="focus_nfc_write_title">Write Focus NFC Tag</string>
+    <string name="focus_nfc_write_button">Write Tag</string>
+    <string name="focus_nfc_no_groups">Create a focus group first</string>
+    <string name="focus_nfc_pick_group">Focus group</string>
+    <string name="focus_nfc_pick_action">When tapped</string>
+    <string name="focus_nfc_unnamed_group">Unnamed group</string>
+    <string name="focus_nfc_action_toggle">Toggle focus</string>
+    <string name="focus_nfc_action_start">Start focus</string>
+    <string name="focus_nfc_action_stop">Stop focus</string>
+    <string name="focus_nfc_duration_input_hint">Duration</string>
+    <string name="focus_nfc_load_button">Load from tag</string>
+    <string name="focus_nfc_load_title">Tap a tag to load</string>
+    <string name="focus_nfc_loaded">Loaded values from tag</string>
+    <string name="focus_nfc_load_invalid">That tag is not a Curbox focus tag</string>
 
     <!-- Group edit titles -->
     <string name="app_group_edit_title">Edit App Group</string>

--- a/app/src/test/java/neth/iecal/curbox/nfc/NfcFocusHandlerTest.kt
+++ b/app/src/test/java/neth/iecal/curbox/nfc/NfcFocusHandlerTest.kt
@@ -1,0 +1,76 @@
+package neth.iecal.curbox.nfc
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * Off-device tests for [NfcFocusHandler.parse], the pure URI decoder behind NFC focus tags.
+ * No Android dependencies: parsing runs on java.net.URI so it can be verified on the JVM.
+ */
+class NfcFocusHandlerTest {
+
+    @Test
+    fun `action from first path segment`() {
+        val r = NfcFocusHandler.parse("curbox://focus/start")
+        assertEquals("start", r?.action)
+        assertNull(r?.groupId)
+        assertNull(r?.minutes)
+    }
+
+    @Test
+    fun `full url with group and mins`() {
+        val r = NfcFocusHandler.parse("curbox://focus/start?group=abc-123&mins=30")
+        assertEquals("start", r?.action)
+        assertEquals("abc-123", r?.groupId)
+        assertEquals(30, r?.minutes)
+    }
+
+    @Test
+    fun `stop action`() {
+        assertEquals("stop", NfcFocusHandler.parse("curbox://focus/stop")?.action)
+    }
+
+    @Test
+    fun `missing action defaults to toggle`() {
+        assertEquals("toggle", NfcFocusHandler.parse("curbox://focus")?.action)
+        assertEquals("toggle", NfcFocusHandler.parse("curbox://focus/")?.action)
+    }
+
+    @Test
+    fun `action query param used when no path segment`() {
+        val r = NfcFocusHandler.parse("curbox://focus?action=stop")
+        assertEquals("stop", r?.action)
+    }
+
+    @Test
+    fun `mins that is not a number is null`() {
+        val r = NfcFocusHandler.parse("curbox://focus/start?mins=abc")
+        assertEquals("start", r?.action)
+        assertNull(r?.minutes)
+    }
+
+    @Test
+    fun `percent-encoded group is decoded`() {
+        val r = NfcFocusHandler.parse("curbox://focus/start?group=a%20b&mins=5")
+        assertEquals("a b", r?.groupId)
+        assertEquals(5, r?.minutes)
+    }
+
+    @Test
+    fun `wrong scheme returns null`() {
+        assertNull(NfcFocusHandler.parse("http://focus/start"))
+    }
+
+    @Test
+    fun `wrong host returns null`() {
+        assertNull(NfcFocusHandler.parse("curbox://unlock/start"))
+    }
+
+    @Test
+    fun `null and garbage input return null`() {
+        assertNull(NfcFocusHandler.parse(null))
+        assertNull(NfcFocusHandler.parse("not a uri"))
+        assertNull(NfcFocusHandler.parse(""))
+    }
+}

--- a/app/src/test/java/neth/iecal/curbox/utils/RestrictionComparatorNfcTest.kt
+++ b/app/src/test/java/neth/iecal/curbox/utils/RestrictionComparatorNfcTest.kt
@@ -1,0 +1,88 @@
+package neth.iecal.curbox.utils
+
+import neth.iecal.curbox.data.models.AppBlockerWarningScreenConfig
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Off-device tests for the NFC clause of [RestrictionComparator.warningConfig].
+ *
+ * `warningConfig` returns true when the new config is the same or stricter (applied immediately)
+ * and false when it weakens the block (parked for the settings-change delay / review). The NFC
+ * unlock clause mirrors the QR one: a tag is a new way to unlock, so tags may only be kept or
+ * removed and a kept tag may not unlock for longer than before.
+ */
+class RestrictionComparatorNfcTest {
+
+    private val base = AppBlockerWarningScreenConfig()
+
+    @Test
+    fun `identical config with nfc disabled is same-or-stricter`() {
+        assertTrue(RestrictionComparator.warningConfig(base, base))
+    }
+
+    @Test
+    fun `enabling nfc unlock is stricter`() {
+        val next = base.copy(isNfcUnlockRequirementEnabled = true, nfcKeys = mapOf("A" to 600_000L))
+        assertTrue(RestrictionComparator.warningConfig(base, next))
+    }
+
+    @Test
+    fun `disabling nfc unlock is a weakening`() {
+        val old = base.copy(isNfcUnlockRequirementEnabled = true, nfcKeys = mapOf("A" to 600_000L))
+        val next = base.copy(isNfcUnlockRequirementEnabled = false, nfcKeys = mapOf())
+        assertFalse(RestrictionComparator.warningConfig(old, next))
+    }
+
+    @Test
+    fun `adding a new nfc tag is a weakening`() {
+        val old = base.copy(isNfcUnlockRequirementEnabled = true, nfcKeys = mapOf("A" to 600_000L))
+        val next = old.copy(nfcKeys = mapOf("A" to 600_000L, "B" to 600_000L))
+        assertFalse(RestrictionComparator.warningConfig(old, next))
+    }
+
+    @Test
+    fun `removing an nfc tag is same-or-stricter`() {
+        val old = base.copy(
+            isNfcUnlockRequirementEnabled = true,
+            nfcKeys = mapOf("A" to 600_000L, "B" to 600_000L)
+        )
+        val next = old.copy(nfcKeys = mapOf("A" to 600_000L))
+        assertTrue(RestrictionComparator.warningConfig(old, next))
+    }
+
+    @Test
+    fun `increasing a kept tag's unlock duration is a weakening`() {
+        val old = base.copy(isNfcUnlockRequirementEnabled = true, nfcKeys = mapOf("A" to 600_000L))
+        val next = old.copy(nfcKeys = mapOf("A" to 1_200_000L))
+        assertFalse(RestrictionComparator.warningConfig(old, next))
+    }
+
+    @Test
+    fun `decreasing a kept tag's unlock duration is stricter`() {
+        val old = base.copy(isNfcUnlockRequirementEnabled = true, nfcKeys = mapOf("A" to 1_200_000L))
+        val next = old.copy(nfcKeys = mapOf("A" to 600_000L))
+        assertTrue(RestrictionComparator.warningConfig(old, next))
+    }
+
+    @Test
+    fun `switching a kept tag to dynamic timing is a weakening`() {
+        val old = base.copy(isNfcUnlockRequirementEnabled = true, nfcKeys = mapOf("A" to 600_000L))
+        val next = old.copy(nfcKeys = mapOf("A" to -1L))
+        assertFalse(RestrictionComparator.warningConfig(old, next))
+    }
+
+    @Test
+    fun `dynamic timing kept as dynamic is same-or-stricter`() {
+        val old = base.copy(isNfcUnlockRequirementEnabled = true, nfcKeys = mapOf("A" to -1L))
+        assertTrue(RestrictionComparator.warningConfig(old, old))
+    }
+
+    @Test
+    fun `narrowing dynamic to a fixed duration is a weakening`() {
+        val old = base.copy(isNfcUnlockRequirementEnabled = true, nfcKeys = mapOf("A" to -1L))
+        val next = old.copy(nfcKeys = mapOf("A" to 600_000L))
+        assertFalse(RestrictionComparator.warningConfig(old, next))
+    }
+}


### PR DESCRIPTION
## NFC tag support

Adds NFC as an option for focus triggering and as an unlock method as a resolution for #187 

### 1. Focus-trigger tags
Tap a tag to start / stop / toggle a focus session.
- Tags hold a self-contained `curbox://focus/<action>?group=&mins=` URI (portable,
  survives reinstall, no app-side state).
- A writer on the Focus page (NFC icon under the "?") lets you pick group/action/duration,
  write a tag, and load values back off an existing tag.

### 2. NFC unlock method
Sits alongside QR/Barcode in the warning-screen unlock config.
- **Generate New** writes a random UUID to a tag; **Scan Existing** registers a tag's UID.
- At the warning screen, tapping a registered tag unlocks with that tag's duration.
- Shares the QR duration dialog and the configured-key list renderer.

### Safety
- Respects non-exitable focus: an NFC stop/swap can't end a locked session early.
- NFC unlock-key changes go through the settings-change delay (added  `nfcKeys` clause to `RestrictionComparator`, mirroring QR).
- A short debounce stops a freshly written tag from instantly re-triggering itself.

### Tests
- `NfcFocusHandlerTest` — URI parsing (12 cases).
- `RestrictionComparatorNfcTest` — unlock-key weakening rules (10 cases).

### Notes
- New `android.permission.NFC` (optional feature; app works without NFC hardware).
- English strings only