### PR TITLE
Add support for Titanium browser URL bar ID

### DIFF
--- a/app/src/main/java/neth/iecal/curbox/hardcoded/BrowserUrlBarIds.kt
+++ b/app/src/main/java/neth/iecal/curbox/hardcoded/BrowserUrlBarIds.kt
@@ -43,4 +43,7 @@ val URL_BAR_ID_LIST = mapOf(
     "com.opera.browser" to BrowserUrlBarInfo(
         displayUrlBarId = "com.opera.browser:id/url_field",
     ),
+    "io.github.jqssun.helium" to BrowserUrlBarInfo(
+        displayUrlBarId = "io.github.jqssun.helium:id/url_bar",
+    ),
 )


### PR DESCRIPTION
Adds support for the Titanium browser.

Project:
https://github.com/jqssun/android-titanium-browser