### PR TITLE
Fixed Instagram feed UI hider after stories scroll away

### DIFF
--- a/app/src/main/java/neth/iecal/curbox/hardcoded/UiHiderSamples.kt
+++ b/app/src/main/java/neth/iecal/curbox/hardcoded/UiHiderSamples.kt
@@ -25,14 +25,18 @@ val DEFAULT_UIHIDER_SCRIPTS: List<UiHiderScript> = listOf(
             top = find(desc="reels tray container")
             nav = find(id="com.instagram.android:id/feed_tab")
 
-            if top != null and top.visible and nav != null and nav.visible {
-                # Ensure anchors are within the visible screen bounds
+            if nav != null and nav.visible and nav.selected {
+                y = load("feed_top")
+                if top != null and top.visible {
                     y = top.bottom
+                    save("feed_top", y)
+                }
+                if y != null {
                     height = nav.top - y
                     if height > 0 {
                         draw(0, y, screen.width, height)
                     }
-                
+                }
             }
         """.trimIndent()
     ),


### PR DESCRIPTION
Resolves #315
Fixes the Instagram home feed UI hider preset so it keeps blocking the feed after the stories tray scrolls off screen.

## What changed

The Instagram feed preset now:

- Uses the stories tray position when it is visible
- Saves that feed top position for later script runs
- Reuses the saved position when Instagram removes the stories tray from the visible UI tree
- Only applies this behavior while the Instagram home feed tab is selected