### PR TITLE
fix: Detect Snapchat Spotlight only on the active tab

### DIFF
--- a/app/src/main/java/neth/iecal/curbox/hardcoded/ReelAppConfig.kt
+++ b/app/src/main/java/neth/iecal/curbox/hardcoded/ReelAppConfig.kt
@@ -83,7 +83,7 @@ class ReelAppConfig {
                     "path:android.widget.HorizontalScrollView[0]>androidx.viewpager.widget.ViewPager[0]>android.view.ViewGroup[0]>androidx.recyclerview.widget.RecyclerView[0]>android.view.ViewGroup[0]>android.view.ViewGroup[0]>android.widget.Button[0]>android.view.ViewGroup[2]>android.view.ViewGroup[0]>android.view.ViewGroup[0]",)),
 
             "com.snapchat.android" to ReelAppData(
-                viewId = "desc:Spotlight",
+                viewId = "desc:Spotlight;selected:true",
                 requiresPresent = listOf(),
                 eventType = AccessibilityEvent.TYPE_WINDOW_CONTENT_CHANGED,
                 dynamicComparator = listOf("path:android.widget.FrameLayout[1]>android.widget.FrameLayout[0]>android.widget.TextView[0]","path:android.widget.FrameLayout[1]>android.widget.FrameLayout[0]>android.widget.TextView[1]")

--- a/app/src/test/java/neth/iecal/curbox/hardcoded/ReelAppConfigTest.kt
+++ b/app/src/test/java/neth/iecal/curbox/hardcoded/ReelAppConfigTest.kt
@@ -1,0 +1,18 @@
+package neth.iecal.curbox.hardcoded
+
+import android.view.accessibility.AccessibilityEvent
+import neth.iecal.curbox.blockers.uihider.NodeFinder
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class ReelAppConfigTest {
+    @Test
+    fun snapchatRequiresTheSpotlightTabToBeSelected() {
+        val snapchat = requireNotNull(ReelAppConfig.reelData["com.snapchat.android"])
+        val selector = NodeFinder.parseSelector(snapchat.viewId)
+
+        assertEquals("Spotlight", selector["desc"])
+        assertEquals(true, selector["selected"])
+        assertEquals(AccessibilityEvent.TYPE_WINDOW_CONTENT_CHANGED, snapchat.eventType)
+    }
+}


### PR DESCRIPTION
With short form video blocking enabled, opening Snapchat can immediately show the scrolling warning on camera, chat, and stories screens. The same false positive occurs in both time based and reel count based modes on Android 14 and Android 16. Snapchat's current `desc:Spotlight` target identifies the persistent Spotlight tab control, which remains visible while another tab is active, so the shared detector treats unrelated Snapchat screens as Spotlight. The fix is limited to Snapchat view detection and does not change settings, blocking thresholds, counting behavior, or the accessibility service lifecycle.

## Summary

Tighten the Snapchat entry in `ReelAppConfig` so its target selector requires the node with the `Spotlight` content description to also be selected, using the composite selector support already provided by `NodeFinder`. This keeps the detection rule in the hardcoded app configuration shared by `ReelBlocker` and `ReelsCountTracker`, so time based and reel count based behavior are corrected together without adding mode specific branches or new runtime abstractions. Add a focused configuration regression test that parses the shipped Snapchat selector and verifies both the Spotlight description and selected state constraint; also retain an assertion on the shared event type so the test documents the complete trigger configuration.

## Test plan

- With Snapchat open on camera, chat, or stories and short form video blocking active outside an allowed time, content change events leave the Spotlight tab unselected and no warning appears.
- With Snapchat open on Spotlight and the blocker active outside an allowed time, the selected Spotlight node matches and the warning still appears.
- With reel count based blocking at its limit, non Spotlight tabs remain usable while the active Spotlight tab is blocked through the same shared configuration.
- The unit test verifies that the Snapchat entry resolves to a selector containing `desc=Spotlight` and `selected=true`, and continues to listen for window content changes.

Closes #349

AI was used for assistance.
